### PR TITLE
fix: support decorators on abstract classes

### DIFF
--- a/.changeset/major-potatoes-attend.md
+++ b/.changeset/major-potatoes-attend.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: support decorators on abstract classes

--- a/src/index.ts
+++ b/src/index.ts
@@ -898,7 +898,7 @@ export function tsPlugin(options?: {
 			}
 
 			canHaveLeadingDecorator(): boolean {
-				return this.match(tt._class);
+				return this.match(tt._class) || this.isAbstractClass();
 			}
 
 			eatContextual(name: string) {

--- a/test/decorators_class_abstract/expected.json
+++ b/test/decorators_class_abstract/expected.json
@@ -1,0 +1,100 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 42,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 3,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "ClassDeclaration",
+			"start": 0,
+			"end": 41,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 2,
+					"column": 30
+				}
+			},
+			"abstract": true,
+			"decorators": [
+				{
+					"type": "Decorator",
+					"start": 0,
+					"end": 10,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 0
+						},
+						"end": {
+							"line": 1,
+							"column": 10
+						}
+					},
+					"expression": {
+						"type": "Identifier",
+						"start": 1,
+						"end": 10,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 1
+							},
+							"end": {
+								"line": 1,
+								"column": 10
+							}
+						},
+						"name": "decorator"
+					}
+				}
+			],
+			"id": {
+				"type": "Identifier",
+				"start": 26,
+				"end": 38,
+				"loc": {
+					"start": {
+						"line": 2,
+						"column": 15
+					},
+					"end": {
+						"line": 2,
+						"column": 27
+					}
+				},
+				"name": "ExampleClass"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 39,
+				"end": 41,
+				"loc": {
+					"start": {
+						"line": 2,
+						"column": 28
+					},
+					"end": {
+						"line": 2,
+						"column": 30
+					}
+				},
+				"body": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/decorators_class_abstract/input.ts
+++ b/test/decorators_class_abstract/input.ts
@@ -1,0 +1,2 @@
+@decorator
+abstract class ExampleClass {}

--- a/test/decorators_class_abstract_export/expected.json
+++ b/test/decorators_class_abstract_export/expected.json
@@ -1,0 +1,118 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 49,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 3,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "ExportNamedDeclaration",
+			"start": 11,
+			"end": 48,
+			"loc": {
+				"start": {
+					"line": 2,
+					"column": 0
+				},
+				"end": {
+					"line": 2,
+					"column": 37
+				}
+			},
+			"exportKind": "value",
+			"declaration": {
+				"type": "ClassDeclaration",
+				"start": 0,
+				"end": 48,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 0
+					},
+					"end": {
+						"line": 2,
+						"column": 37
+					}
+				},
+				"abstract": true,
+				"decorators": [
+					{
+						"type": "Decorator",
+						"start": 0,
+						"end": 10,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 0
+							},
+							"end": {
+								"line": 1,
+								"column": 10
+							}
+						},
+						"expression": {
+							"type": "Identifier",
+							"start": 1,
+							"end": 10,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 1
+								},
+								"end": {
+									"line": 1,
+									"column": 10
+								}
+							},
+							"name": "decorator"
+						}
+					}
+				],
+				"id": {
+					"type": "Identifier",
+					"start": 33,
+					"end": 45,
+					"loc": {
+						"start": {
+							"line": 2,
+							"column": 22
+						},
+						"end": {
+							"line": 2,
+							"column": 34
+						}
+					},
+					"name": "ExampleClass"
+				},
+				"superClass": null,
+				"body": {
+					"type": "ClassBody",
+					"start": 46,
+					"end": 48,
+					"loc": {
+						"start": {
+							"line": 2,
+							"column": 35
+						},
+						"end": {
+							"line": 2,
+							"column": 37
+						}
+					},
+					"body": []
+				}
+			},
+			"specifiers": [],
+			"source": null
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/decorators_class_abstract_export/input.ts
+++ b/test/decorators_class_abstract_export/input.ts
@@ -1,0 +1,2 @@
+@decorator
+export abstract class ExampleClass {}


### PR DESCRIPTION
See #31

Decorators on abstract classes currently fail to parse when not exported:

```ts
@decorator
abstract class ExampleClass {}
```

> SyntaxError: Leading decorators must be attached to a class declaration.

Already works:

```ts
@decorator
export abstract class ExampleClass {}
```

This fixes it, adding the test case and a second for when `export` is included, which already works.