### PR TITLE
docs: add missing changelog entry for PR #38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Patch Changes
 
+- fix: AssignmentPattern `loc.start` should be assigned a Position vs a Location ([#38](https://github.com/sveltejs/acorn-typescript/pull/38))
+
 - fix: parse private method overloads ([#30](https://github.com/sveltejs/acorn-typescript/pull/30))
 
 - fix: exit scope for bodiless class methods to pass export validation ([#33](https://github.com/sveltejs/acorn-typescript/pull/33))


### PR DESCRIPTION
forgot to put in a changeset in the pr, this is to update the changelog.  the commit did make it to the 1.0.9 release.