### PR TITLE
fix: generateAcornTypeScript breaks when two acorn copies exist

### DIFF
--- a/.changeset/short-mammals-kick.md
+++ b/.changeset/short-mammals-kick.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: use user-provided acorn-copy for ts plugin

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 minimumReleaseAge: 1440
 packages:
-  - /
+  - '.'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+minimumReleaseAge: 1440
+packages:
+  - /

--- a/src/extentions/import-assertions.ts
+++ b/src/extentions/import-assertions.ts
@@ -1,6 +1,6 @@
 import { AcornParseClass } from '../middleware';
 import { AcornTypeScript } from '../types';
-import * as acornNamespace from 'acorn';
+import type * as acornNamespace from 'acorn';
 
 export default function generateParseImportAssertions(
 	Parse: typeof AcornParseClass,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { skipWhiteSpaceToLineBreak } from './whitespace';
 import { checkKeyName, DestructuringErrors, isPrivateNameConflicted } from './parseutil';
 import { DecoratorsError, TypeScriptError } from './error';
 import { AcornParseClass } from './middleware';
-import { Node, TokenType, Position, Options } from 'acorn';
+import type { Node, TokenType, Position, Options } from 'acorn';
 import generateParseDecorators from './extentions/decorators';
 import generateJsxParser from './extentions/jsx';
 import generateParseImportAssertions from './extentions/import-assertions';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,4 @@
-import type { Parser, Node, TokenType, Position, tokTypes } from 'acorn';
-import type { Options } from 'acorn';
+import type { Parser, Node, TokenType, Position, tokTypes, Options } from 'acorn';
 
 // This mostly exist to make sure that we get _some_ kind of type intellisense. It's achieved by replicating the internal acorn types
 export declare class AcornParseClass extends Parser {

--- a/src/tokenType.ts
+++ b/src/tokenType.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { TokenType, keywordTypes, tokTypes, TokContext } from 'acorn';
+import { TokenType, TokContext } from 'acorn';
 import { AcornTypeScript } from './types';
 
 const startsExpr = true;
@@ -12,12 +12,13 @@ function kwLike(_name, options: any = {}) {
 }
 
 const acornTypeScriptMap = new WeakMap();
-const keywordTypeValues = Object.values(keywordTypes);
 
 export function generateAcornTypeScript(_acorn: any): AcornTypeScript {
 	const acorn = _acorn.Parser.acorn || _acorn;
 	let acornTypeScript = acornTypeScriptMap.get(acorn);
 	if (!acornTypeScript) {
+		const { tokTypes, keywordTypes } = acorn;
+		const keywordTypeValues = Object.values(keywordTypes);
 		const tsKwTokenType = generateTsKwTokenType();
 		const tsKwTokenTypeValues = Object.values(tsKwTokenType);
 		const tsTokenType = generateTsTokenType();

--- a/src/tokenType.ts
+++ b/src/tokenType.ts
@@ -1,21 +1,15 @@
-// @ts-ignore
-import { TokenType, TokContext } from 'acorn';
-import { AcornTypeScript } from './types';
+import type { TokenType } from 'acorn';
+import type { AcornTypeScript } from './types';
+import type { AcornParseClass } from './middleware';
 
 const startsExpr = true;
-
-// Succinct definitions of keyword token types
-
-function kwLike(_name, options: any = {}) {
-	// @ts-expect-error
-	return new TokenType('name', options);
-}
-
 const acornTypeScriptMap = new WeakMap();
 
 export function generateAcornTypeScript(_acorn: any): AcornTypeScript {
-	const acorn = _acorn.Parser.acorn || _acorn;
+	// Do NOT use any value imports from 'acorn' here, as the passed version might be different to ours
+	const acorn: (typeof AcornParseClass)['acorn'] = _acorn.Parser.acorn || _acorn;
 	let acornTypeScript = acornTypeScriptMap.get(acorn);
+
 	if (!acornTypeScript) {
 		const { tokTypes, keywordTypes } = acorn;
 		const keywordTypeValues = Object.values(keywordTypes);
@@ -110,45 +104,52 @@ export function generateAcornTypeScript(_acorn: any): AcornTypeScript {
 	}
 
 	return acornTypeScript;
-}
 
-function generateTsTokenContext() {
-	return {
-		tc_oTag: new TokContext('<tag', false, false),
-		tc_cTag: new TokContext('</tag', false, false),
-		tc_expr: new TokContext('<tag>...</tag>', true, true)
-	};
-}
+	// Succinct definitions of keyword token types
 
-function generateTsTokenType() {
-	return {
+	function kwLike(_name, options: any = {}) {
 		// @ts-expect-error
-		at: new TokenType('@'),
-		// @ts-expect-error
-		jsxName: new TokenType('jsxName'),
-		// @ts-expect-error
-		jsxText: new TokenType('jsxText', { beforeExpr: true }),
-		// @ts-expect-error
-		jsxTagStart: new TokenType('jsxTagStart', { startsExpr: true }),
-		// @ts-expect-error
-		jsxTagEnd: new TokenType('jsxTagEnd')
-	};
-}
+		return new acorn.TokenType('name', options);
+	}
 
-function generateTsKwTokenType() {
-	return {
-		assert: kwLike('assert', { startsExpr }),
-		asserts: kwLike('asserts', { startsExpr }),
-		global: kwLike('global', { startsExpr }),
-		keyof: kwLike('keyof', { startsExpr }),
-		readonly: kwLike('readonly', { startsExpr }),
-		unique: kwLike('unique', { startsExpr }),
-		abstract: kwLike('abstract', { startsExpr }),
-		declare: kwLike('declare', { startsExpr }),
-		enum: kwLike('enum', { startsExpr }),
-		module: kwLike('module', { startsExpr }),
-		namespace: kwLike('namespace', { startsExpr }),
-		interface: kwLike('interface', { startsExpr }),
-		type: kwLike('type', { startsExpr })
-	};
+	function generateTsTokenContext() {
+		return {
+			tc_oTag: new acorn.TokContext('<tag', false, false),
+			tc_cTag: new acorn.TokContext('</tag', false, false),
+			tc_expr: new acorn.TokContext('<tag>...</tag>', true, true)
+		};
+	}
+
+	function generateTsTokenType() {
+		return {
+			// @ts-expect-error
+			at: new acorn.TokenType('@'),
+			// @ts-expect-error
+			jsxName: new acorn.TokenType('jsxName'),
+			// @ts-expect-error
+			jsxText: new acorn.TokenType('jsxText', { beforeExpr: true }),
+			// @ts-expect-error
+			jsxTagStart: new acorn.TokenType('jsxTagStart', { startsExpr: true }),
+			// @ts-expect-error
+			jsxTagEnd: new acorn.TokenType('jsxTagEnd')
+		};
+	}
+
+	function generateTsKwTokenType() {
+		return {
+			assert: kwLike('assert', { startsExpr }),
+			asserts: kwLike('asserts', { startsExpr }),
+			global: kwLike('global', { startsExpr }),
+			keyof: kwLike('keyof', { startsExpr }),
+			readonly: kwLike('readonly', { startsExpr }),
+			unique: kwLike('unique', { startsExpr }),
+			abstract: kwLike('abstract', { startsExpr }),
+			declare: kwLike('declare', { startsExpr }),
+			enum: kwLike('enum', { startsExpr }),
+			module: kwLike('module', { startsExpr }),
+			namespace: kwLike('namespace', { startsExpr }),
+			interface: kwLike('interface', { startsExpr }),
+			type: kwLike('type', { startsExpr })
+		};
+	}
 }


### PR DESCRIPTION
Fixes #41