### PR TITLE
fix: avoid emitting duplicate comments

### DIFF
--- a/.changeset/proud-pants-burn.md
+++ b/.changeset/proud-pants-burn.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: avoid emitting duplicate comments

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,7 @@ export function tsPlugin(options?: {
 			preValue: any = null;
 			preToken: any = null;
 			isLookahead: boolean = false;
+			maxEmittedCommentStart: number = -1;
 			isAmbientContext: boolean = false;
 			inAbstractClass: boolean = false;
 			inType: boolean = false;
@@ -673,7 +674,8 @@ export function tsPlugin(options?: {
 
 				if (this.isLookahead) return;
 
-				if (this.options.onComment) {
+				if (this.options.onComment && start > this.maxEmittedCommentStart) {
+					this.maxEmittedCommentStart = start;
 					this.options.onComment(
 						true,
 						this.input.slice(start + 2, end),
@@ -696,7 +698,8 @@ export function tsPlugin(options?: {
 
 				if (this.isLookahead) return;
 
-				if (this.options.onComment)
+				if (this.options.onComment && start > this.maxEmittedCommentStart) {
+					this.maxEmittedCommentStart = start;
 					this.options.onComment(
 						false,
 						this.input.slice(start + startSkip, this.pos),
@@ -706,6 +709,7 @@ export function tsPlugin(options?: {
 						startLoc,
 						this.curPosition()
 					);
+				}
 			}
 
 			finishToken(type: TokenType, val?: string): any {

--- a/test/commentDuplication.test.ts
+++ b/test/commentDuplication.test.ts
@@ -49,6 +49,10 @@ describe('comment duplication (onComment double-fire)', () => {
 			expect(maxEmissions('const f = (x): T /* c */ => 0;')).toBe(1);
 		});
 
+		it('inline object type parameter with JSDoc', () => {
+			expect(maxEmissions('function f(opts: { /** c */ a: string }) {}')).toBe(1);
+		});
+
 		it('angle-bracket type assertion', () => {
 			expect(maxEmissions('const x = </* c */ T>y;')).toBe(1);
 		});

--- a/test/commentDuplication.test.ts
+++ b/test/commentDuplication.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { Parser } from './utils';
+
+/**
+ * Parse `input` and return the highest number of times any single comment span
+ * was reported to `onComment`.
+ *
+ * Every input below contains exactly one comment, so the result should be `1`:
+ * a `2`+ means it was double-reported, and a `0` means it was dropped.
+ */
+function maxEmissions(input: string): number {
+	const counts = new Map<string, number>();
+	Parser.parse(input, {
+		sourceType: 'module',
+		ecmaVersion: 'latest',
+		onComment: (_block: boolean, text: string, start: number, end: number) => {
+			const key = `${start},${end}::${text}`;
+			counts.set(key, (counts.get(key) ?? 0) + 1);
+		}
+	});
+	return Math.max(0, ...counts.values());
+}
+
+describe('comment duplication (onComment double-fire)', () => {
+	// `tsLookAhead` predicate paths: a pure peek re-lexes a region while
+	// classifying it but never sets `isLookahead`, so the re-lexed comments leak
+	describe('tsLookAhead predicates', () => {
+		it('computed class key', () => {
+			expect(maxEmissions('class C { [ /* c */ foo ]() {} }')).toBe(1);
+		});
+
+		it('index signature (interface)', () => {
+			expect(maxEmissions('interface I { [/* c */ k: string]: number }')).toBe(1);
+		});
+
+		it('index signature (type literal)', () => {
+			expect(maxEmissions('type T = { [/* c */ k: string]: number };')).toBe(1);
+		});
+
+		it('function type parameter', () => {
+			expect(maxEmissions('type F = (/* c */ a: number) => void;')).toBe(1);
+		});
+	});
+
+	// `tryParse` backtrack paths: a speculative parse keeps its result on success,
+	// so its comments cannot be blanket-suppressed, and only dedup/restore fixes them.
+	describe('tryParse backtracking', () => {
+		it('arrow return type', () => {
+			expect(maxEmissions('const f = (x): T /* c */ => 0;')).toBe(1);
+		});
+
+		it('angle-bracket type assertion', () => {
+			expect(maxEmissions('const x = </* c */ T>y;')).toBe(1);
+		});
+
+		it('method signature return type before `;`', () => {
+			expect(maxEmissions('interface I { m(): T /* c */; }')).toBe(1);
+		});
+
+		it('abstract method return type before `;`', () => {
+			expect(maxEmissions('abstract class C { abstract m(): T /* c */; }')).toBe(1);
+		});
+
+		it('function return type before `{` body', () => {
+			expect(maxEmissions('function f(): T /* c */ {}')).toBe(1);
+		});
+	});
+
+	// guard against an overly-aggressive fix that drops or suppresses legitimate comments
+	describe('controls (must already be single)', () => {
+		it('comment after a statement', () => {
+			expect(maxEmissions('const x = 1; /* c */')).toBe(1);
+		});
+
+		it('`as` expression (no backtrack)', () => {
+			expect(maxEmissions('const x = y as T /* c */;')).toBe(1);
+		});
+
+		it('plain typed parameter (no re-parse)', () => {
+			expect(maxEmissions('function f(a: number /* c */) {}')).toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
See #49 (I used AI to find and fix this)

This bluntly but correctly avoids emitting duplicate comments. It looks like an architecturally cleaner fix would be to buffer comments and flush at commit, but that's a bit more code and subtly changes the `onComment` timing, so I think this is the simplest and least-disruptive fix. I'm happy to do the deeper, arguably more-correct version.

The fixture system doesn't handle `onComment` so I added tests instead. (9 failing before the fix) I can wire that up if fixtures are preferred.