### PR TITLE
fix: allow `in` operator inside parenthesized for-loop initializers

### DIFF
--- a/.changeset/quick-in-parens.md
+++ b/.changeset/quick-in-parens.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: allow `in` operator inside parenthesized expressions in a `for` loop initializer

--- a/src/index.ts
+++ b/src/index.ts
@@ -4416,7 +4416,7 @@ export function tsPlugin(options?: {
 							break;
 						} else {
 							exprList.push(
-								this.parseMaybeAssign(forInit, refDestructuringErrors, this.parseParenItem)
+								this.parseMaybeAssign(false, refDestructuringErrors, this.parseParenItem)
 							);
 						}
 					}

--- a/test/for_in_expression_in_var_init/expected.json
+++ b/test/for_in_expression_in_var_init/expected.json
@@ -1,0 +1,277 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 61,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 1,
+			"column": 61
+		}
+	},
+	"body": [
+		{
+			"type": "ForStatement",
+			"start": 0,
+			"end": 61,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 61
+				}
+			},
+			"init": {
+				"type": "VariableDeclaration",
+				"start": 5,
+				"end": 45,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 5
+					},
+					"end": {
+						"line": 1,
+						"column": 45
+					}
+				},
+				"declarations": [
+					{
+						"type": "VariableDeclarator",
+						"start": 9,
+						"end": 38,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 9
+							},
+							"end": {
+								"line": 1,
+								"column": 38
+							}
+						},
+						"id": {
+							"type": "Identifier",
+							"start": 9,
+							"end": 16,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 9
+								},
+								"end": {
+									"line": 1,
+									"column": 16
+								}
+							},
+							"name": "hasFlag"
+						},
+						"init": {
+							"type": "BinaryExpression",
+							"start": 20,
+							"end": 37,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 20
+								},
+								"end": {
+									"line": 1,
+									"column": 37
+								}
+							},
+							"left": {
+								"type": "Literal",
+								"start": 20,
+								"end": 26,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 20
+									},
+									"end": {
+										"line": 1,
+										"column": 26
+									}
+								},
+								"value": "flag",
+								"raw": "'flag'"
+							},
+							"operator": "in",
+							"right": {
+								"type": "Identifier",
+								"start": 30,
+								"end": 37,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 30
+									},
+									"end": {
+										"line": 1,
+										"column": 37
+									}
+								},
+								"name": "options"
+							}
+						}
+					},
+					{
+						"type": "VariableDeclarator",
+						"start": 40,
+						"end": 45,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 40
+							},
+							"end": {
+								"line": 1,
+								"column": 45
+							}
+						},
+						"id": {
+							"type": "Identifier",
+							"start": 40,
+							"end": 41,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 40
+								},
+								"end": {
+									"line": 1,
+									"column": 41
+								}
+							},
+							"name": "i"
+						},
+						"init": {
+							"type": "Literal",
+							"start": 44,
+							"end": 45,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 44
+								},
+								"end": {
+									"line": 1,
+									"column": 45
+								}
+							},
+							"value": 0,
+							"raw": "0"
+						}
+					}
+				],
+				"kind": "var"
+			},
+			"test": {
+				"type": "BinaryExpression",
+				"start": 47,
+				"end": 52,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 47
+					},
+					"end": {
+						"line": 1,
+						"column": 52
+					}
+				},
+				"left": {
+					"type": "Identifier",
+					"start": 47,
+					"end": 48,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 47
+						},
+						"end": {
+							"line": 1,
+							"column": 48
+						}
+					},
+					"name": "i"
+				},
+				"operator": "<",
+				"right": {
+					"type": "Literal",
+					"start": 51,
+					"end": 52,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 51
+						},
+						"end": {
+							"line": 1,
+							"column": 52
+						}
+					},
+					"value": 1,
+					"raw": "1"
+				}
+			},
+			"update": {
+				"type": "UpdateExpression",
+				"start": 54,
+				"end": 57,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 54
+					},
+					"end": {
+						"line": 1,
+						"column": 57
+					}
+				},
+				"operator": "++",
+				"prefix": false,
+				"argument": {
+					"type": "Identifier",
+					"start": 54,
+					"end": 55,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 54
+						},
+						"end": {
+							"line": 1,
+							"column": 55
+						}
+					},
+					"name": "i"
+				}
+			},
+			"body": {
+				"type": "BlockStatement",
+				"start": 59,
+				"end": 61,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 59
+					},
+					"end": {
+						"line": 1,
+						"column": 61
+					}
+				},
+				"body": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/for_in_expression_in_var_init/input.ts
+++ b/test/for_in_expression_in_var_init/input.ts
@@ -1,0 +1,1 @@
+for (var hasFlag = ('flag' in options), i = 0; i < 1; i++) {}


### PR DESCRIPTION
Fixes a parse error on the `in` operator when it appears inside parentheses in a `for`-loop initializer. For example:

```ts
for (var hasFlag = ('flag' in options), i = 0; i < 1; i++) {}
```

This throws `SyntaxError: Unexpected token (1:27)` with the plugin, but parses fine with plain acorn.

Explainer:

https://github.com/sveltejs/acorn-typescript/commit/163f0cf5a2275a22959ba7b94b507a68ade3ec6a seems like sneaked in unrelated change that this PR is reverting. The described problem commit was fixing seems to have no relation and the test added then (which where refactored to input fixture https://github.com/sveltejs/acorn-typescript/blob/main/test/function_type_test_arrow_function_with_optional_param/input.ts +  expected ~snapshot https://github.com/sveltejs/acorn-typescript/blob/main/test/function_type_test_arrow_function_with_optional_param/expected.json) continue to pass.

"plain acorn" path also does hardcode `false` in what I think is [equivalent path](https://github.com/acornjs/acorn/blob/8.17.0/acorn/src/expression.js#L647)

My explanation here is that special `in` operator handling should be only handled at the top-level `for` init expression to handle `for-in`. Once you walk into nested expressions - it's no longer direct `for` init, so special `for-in` init handling should not apply anymore. 