### PR TITLE
fix: restore scope state after failed speculative parse in tryParse

### DIFF
--- a/.changeset/rare-scopes-rollback.md
+++ b/.changeset/rare-scopes-rollback.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Restore scope state after a failed speculative parse, so a leaked scope no longer causes a later `export { x }` to fail with "Export 'x' is not defined".

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,6 +336,21 @@ export function tsPlugin(options?: {
 				const abortSignal: {
 					node: T | null;
 				} = { node: null };
+				// The lookahead state restored on failure below only covers the lexer/token
+				// position, not the scope-tracking state. A speculative parse can enter scopes
+				// (e.g. for a function expression while probing an arrow return type), so we
+				// snapshot that state up front and roll it back whenever we roll back the tokens,
+				// otherwise leaked scopes corrupt later binding/export resolution.
+				const oldScopeStack = this.scopeStack.slice();
+				const oldImportsStack = this.importsStack.slice();
+				const oldLabels = this.labels.slice();
+				const oldUndefinedExports = Object.assign(Object.create(null), this.undefinedExports);
+				const restoreScopeState = () => {
+					this.scopeStack = oldScopeStack;
+					this.importsStack = oldImportsStack;
+					this.labels = oldLabels;
+					this.undefinedExports = oldUndefinedExports;
+				};
 				try {
 					const node = fn((node = null) => {
 						abortSignal.node = node;
@@ -352,6 +367,7 @@ export function tsPlugin(options?: {
 				} catch (error) {
 					const failState = this.getCurLookaheadState();
 					this.setLookaheadState(oldState);
+					restoreScopeState();
 					if (error instanceof SyntaxError) {
 						return {
 							node: null,

--- a/test/conditional_paren_consequent_export_scope_leak/expected.json
+++ b/test/conditional_paren_consequent_export_scope_leak/expected.json
@@ -1,0 +1,399 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 92,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 6,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "FunctionDeclaration",
+			"start": 0,
+			"end": 59,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 9,
+				"end": 10,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 9
+					},
+					"end": {
+						"line": 1,
+						"column": 10
+					}
+				},
+				"name": "m"
+			},
+			"expression": false,
+			"generator": false,
+			"async": false,
+			"params": [],
+			"body": {
+				"type": "BlockStatement",
+				"start": 13,
+				"end": 59,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 13
+					},
+					"end": {
+						"line": 3,
+						"column": 1
+					}
+				},
+				"body": [
+					{
+						"type": "ExpressionStatement",
+						"start": 16,
+						"end": 57,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 1
+							},
+							"end": {
+								"line": 2,
+								"column": 42
+							}
+						},
+						"expression": {
+							"type": "ConditionalExpression",
+							"start": 16,
+							"end": 56,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 1
+								},
+								"end": {
+									"line": 2,
+									"column": 41
+								}
+							},
+							"test": {
+								"type": "Identifier",
+								"start": 16,
+								"end": 17,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 1
+									},
+									"end": {
+										"line": 2,
+										"column": 2
+									}
+								},
+								"name": "_"
+							},
+							"consequent": {
+								"type": "Identifier",
+								"start": 21,
+								"end": 22,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 6
+									},
+									"end": {
+										"line": 2,
+										"column": 7
+									}
+								},
+								"name": "t"
+							},
+							"alternate": {
+								"type": "AssignmentExpression",
+								"start": 27,
+								"end": 55,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 12
+									},
+									"end": {
+										"line": 2,
+										"column": 40
+									}
+								},
+								"operator": "=",
+								"left": {
+									"type": "Identifier",
+									"start": 27,
+									"end": 28,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 12
+										},
+										"end": {
+											"line": 2,
+											"column": 13
+										}
+									},
+									"name": "t"
+								},
+								"right": {
+									"type": "FunctionExpression",
+									"start": 32,
+									"end": 54,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 17
+										},
+										"end": {
+											"line": 2,
+											"column": 39
+										}
+									},
+									"id": null,
+									"expression": false,
+									"generator": false,
+									"async": false,
+									"params": [],
+									"body": {
+										"type": "BlockStatement",
+										"start": 44,
+										"end": 54,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 29
+											},
+											"end": {
+												"line": 2,
+												"column": 39
+											}
+										},
+										"body": [
+											{
+												"type": "ExpressionStatement",
+												"start": 46,
+												"end": 52,
+												"loc": {
+													"start": {
+														"line": 2,
+														"column": 31
+													},
+													"end": {
+														"line": 2,
+														"column": 37
+													}
+												},
+												"expression": {
+													"type": "BinaryExpression",
+													"start": 46,
+													"end": 52,
+													"loc": {
+														"start": {
+															"line": 2,
+															"column": 31
+														},
+														"end": {
+															"line": 2,
+															"column": 37
+														}
+													},
+													"left": {
+														"type": "Identifier",
+														"start": 46,
+														"end": 47,
+														"loc": {
+															"start": {
+																"line": 2,
+																"column": 31
+															},
+															"end": {
+																"line": 2,
+																"column": 32
+															}
+														},
+														"name": "t"
+													},
+													"operator": ">>",
+													"right": {
+														"type": "Literal",
+														"start": 51,
+														"end": 52,
+														"loc": {
+															"start": {
+																"line": 2,
+																"column": 36
+															},
+															"end": {
+																"line": 2,
+																"column": 37
+															}
+														},
+														"value": 5,
+														"raw": "5"
+													}
+												}
+											}
+										]
+									}
+								}
+							}
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "VariableDeclaration",
+			"start": 60,
+			"end": 71,
+			"loc": {
+				"start": {
+					"line": 4,
+					"column": 0
+				},
+				"end": {
+					"line": 4,
+					"column": 11
+				}
+			},
+			"declarations": [
+				{
+					"type": "VariableDeclarator",
+					"start": 64,
+					"end": 70,
+					"loc": {
+						"start": {
+							"line": 4,
+							"column": 4
+						},
+						"end": {
+							"line": 4,
+							"column": 10
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 64,
+						"end": 66,
+						"loc": {
+							"start": {
+								"line": 4,
+								"column": 4
+							},
+							"end": {
+								"line": 4,
+								"column": 6
+							}
+						},
+						"name": "en"
+					},
+					"init": {
+						"type": "Literal",
+						"start": 69,
+						"end": 70,
+						"loc": {
+							"start": {
+								"line": 4,
+								"column": 9
+							},
+							"end": {
+								"line": 4,
+								"column": 10
+							}
+						},
+						"value": 1,
+						"raw": "1"
+					}
+				}
+			],
+			"kind": "var"
+		},
+		{
+			"type": "ExportNamedDeclaration",
+			"start": 72,
+			"end": 91,
+			"loc": {
+				"start": {
+					"line": 5,
+					"column": 0
+				},
+				"end": {
+					"line": 5,
+					"column": 19
+				}
+			},
+			"exportKind": "value",
+			"declaration": null,
+			"specifiers": [
+				{
+					"type": "ExportSpecifier",
+					"start": 81,
+					"end": 88,
+					"loc": {
+						"start": {
+							"line": 5,
+							"column": 9
+						},
+						"end": {
+							"line": 5,
+							"column": 16
+						}
+					},
+					"local": {
+						"type": "Identifier",
+						"start": 81,
+						"end": 83,
+						"loc": {
+							"start": {
+								"line": 5,
+								"column": 9
+							},
+							"end": {
+								"line": 5,
+								"column": 11
+							}
+						},
+						"name": "en"
+					},
+					"exported": {
+						"type": "Identifier",
+						"start": 87,
+						"end": 88,
+						"loc": {
+							"start": {
+								"line": 5,
+								"column": 15
+							},
+							"end": {
+								"line": 5,
+								"column": 16
+							}
+						},
+						"name": "X"
+					},
+					"exportKind": "value"
+				}
+			],
+			"source": null
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/conditional_paren_consequent_export_scope_leak/input.ts
+++ b/test/conditional_paren_consequent_export_scope_leak/input.ts
@@ -1,0 +1,5 @@
+function m() {
+	_ ? (t) : (t = (function () { t >> 5 }));
+}
+var en = 1;
+export { en as X };


### PR DESCRIPTION
Speculative parses could leak an entered scope onto scopeStack, causing later `export { x }` to fail with "Export 'x' is not defined".