### PR TITLE
fix: parse const type parameters on classes

### DIFF
--- a/.changeset/calm-classes-parse.md
+++ b/.changeset/calm-classes-parse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: parse const type parameters on classes

--- a/src/index.ts
+++ b/src/index.ts
@@ -2224,6 +2224,23 @@ export function tsPlugin(options?: {
 				});
 			}
 
+			tsParseClassTypeParameterModifiers(node: any) {
+				this.tsParseModifiers({
+					modified: node,
+					allowedModifiers: ['const', 'in', 'out'],
+					disallowedModifiers: [
+						'public',
+						'private',
+						'protected',
+						'readonly',
+						'declare',
+						'abstract',
+						'override'
+					],
+					errorTemplate: TypeScriptError.InvalidModifierOnTypeParameter
+				});
+			}
+
 			// Handle type assertions
 			parseMaybeUnary(
 				refExpressionErrors?: any,
@@ -3616,7 +3633,9 @@ export function tsPlugin(options?: {
 					return;
 				}
 				super.parseClassId(node, isStatement);
-				const typeParameters = this.tsTryParseTypeParameters(this.tsParseInOutModifiers.bind(this));
+				const typeParameters = this.tsTryParseTypeParameters(
+					this.tsParseClassTypeParameterModifiers.bind(this)
+				);
 				if (typeParameters) node.typeParameters = typeParameters;
 			}
 

--- a/test/class_generic_with_const_type_parameter/expected.json
+++ b/test/class_generic_with_const_type_parameter/expected.json
@@ -1,0 +1,100 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 20,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 2,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "ClassDeclaration",
+			"start": 0,
+			"end": 19,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 19
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 6,
+				"end": 7,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 6
+					},
+					"end": {
+						"line": 1,
+						"column": 7
+					}
+				},
+				"name": "C"
+			},
+			"typeParameters": {
+				"type": "TSTypeParameterDeclaration",
+				"start": 7,
+				"end": 16,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 7
+					},
+					"end": {
+						"line": 1,
+						"column": 16
+					}
+				},
+				"params": [
+					{
+						"type": "TSTypeParameter",
+						"start": 8,
+						"end": 15,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 8
+							},
+							"end": {
+								"line": 1,
+								"column": 15
+							}
+						},
+						"const": true,
+						"name": "T"
+					}
+				]
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 17,
+				"end": 19,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 17
+					},
+					"end": {
+						"line": 1,
+						"column": 19
+					}
+				},
+				"body": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/class_generic_with_const_type_parameter/input.ts
+++ b/test/class_generic_with_const_type_parameter/input.ts
@@ -1,0 +1,1 @@
+class C<const T> {}


### PR DESCRIPTION
Allow class declarations to combine const and variance type parameter modifiers.

Add a minimal parser fixture for class C<const T>.

- Close: #58 