### PR TITLE
fix: parse keywords used as tuple labels

### DIFF
--- a/.changeset/quick-tuples-parse.md
+++ b/.changeset/quick-tuples-parse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: parse keywords used as tuple labels

--- a/src/index.ts
+++ b/src/index.ts
@@ -1649,39 +1649,43 @@ export function tsPlugin(options?: {
 				return this.finishNode(node, 'TSTypeLiteral');
 			}
 
+			tsIsTupleElementLabel(): boolean {
+				if (!tokenIsKeywordOrIdentifier(this.type)) return false;
+
+				const nextToken = this.lookahead();
+				if (nextToken.type === tt.colon) return true;
+				if (nextToken.type !== tt.question) return false;
+
+				return this.lookahead(2).type === tt.colon;
+			}
+
 			tsParseTupleElementType(): any {
 				// parses `...TsType[]`
 
 				const startLoc = this.startLoc;
 				const startPos = this['start'];
 				const rest = this.eat(tt.ellipsis);
-				let type: any = this.tsParseType();
-				const optional = this.eat(tt.question);
-				const labeled = this.eat(tt.colon);
+				let type: any;
 
-				if (labeled) {
-					const labeledNode = this.startNodeAtNode(type);
-					labeledNode.optional = optional;
-
-					if (
-						type.type === 'TSTypeReference' &&
-						!type.typeArguments &&
-						type.typeName.type === 'Identifier'
-					) {
-						labeledNode.label = type.typeName as any;
-					} else {
-						this.raise(type.start, TypeScriptError.InvalidTupleMemberLabel);
-						// nodes representing the invalid source.
-						labeledNode.label = type;
-					}
-
+				if (this.tsIsTupleElementLabel()) {
+					const labeledNode = this.startNode();
+					labeledNode.label = this.parseIdent(true);
+					labeledNode.optional = this.eat(tt.question);
+					this.expect(tt.colon);
 					labeledNode.elementType = this.tsParseType();
 					type = this.finishNode(labeledNode, 'TSNamedTupleMember');
-				} else if (optional) {
-					const optionalTypeNode = this.startNodeAtNode(type);
+				} else {
+					type = this.tsParseType();
+					const optional = this.eat(tt.question);
+					if (this.eat(tt.colon)) {
+						this.raise(type.start, TypeScriptError.InvalidTupleMemberLabel);
+					}
+					if (optional) {
+						const optionalTypeNode = this.startNodeAtNode(type);
 
-					optionalTypeNode.typeAnnotation = type;
-					type = this.finishNode(optionalTypeNode, 'TSOptionalType');
+						optionalTypeNode.typeAnnotation = type;
+						type = this.finishNode(optionalTypeNode, 'TSOptionalType');
+					}
 				}
 
 				if (rest) {

--- a/test/tuple_keyword_label/expected.json
+++ b/test/tuple_keyword_label/expected.json
@@ -1,0 +1,113 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 29,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 2,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "TSTypeAliasDeclaration",
+			"start": 0,
+			"end": 28,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 28
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 5,
+				"end": 6,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 5
+					},
+					"end": {
+						"line": 1,
+						"column": 6
+					}
+				},
+				"name": "T"
+			},
+			"typeAnnotation": {
+				"type": "TSTupleType",
+				"start": 9,
+				"end": 27,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 9
+					},
+					"end": {
+						"line": 1,
+						"column": 27
+					}
+				},
+				"elementTypes": [
+					{
+						"type": "TSNamedTupleMember",
+						"start": 10,
+						"end": 26,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 10
+							},
+							"end": {
+								"line": 1,
+								"column": 26
+							}
+						},
+						"label": {
+							"type": "Identifier",
+							"start": 10,
+							"end": 18,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 10
+								},
+								"end": {
+									"line": 1,
+									"column": 18
+								}
+							},
+							"name": "function"
+						},
+						"optional": false,
+						"elementType": {
+							"type": "TSStringKeyword",
+							"start": 20,
+							"end": 26,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 20
+								},
+								"end": {
+									"line": 1,
+									"column": 26
+								}
+							}
+						}
+					}
+				]
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/tuple_keyword_label/input.ts
+++ b/test/tuple_keyword_label/input.ts
@@ -1,0 +1,1 @@
+type T = [function: string];


### PR DESCRIPTION
Recognize keyword and identifier labels before parsing tuple element types.

Add a minimal parser fixture for type T = [function: string].

- Close: #60 