### PR TITLE
fix: parse type predicates for parameters named asserts

### DIFF
--- a/.changeset/calm-predicates-parse.md
+++ b/.changeset/calm-predicates-parse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: parse type predicates for parameters named asserts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1383,6 +1383,17 @@ export function tsPlugin(options?: {
 					const t = this.startNode();
 					this.expect(returnToken);
 					const node = this.startNode();
+					const typePredicateVariable =
+						this.tsIsIdentifier() && this.tsTryParse(this.tsParseTypePredicatePrefix.bind(this));
+
+					if (typePredicateVariable) {
+						const type = this.tsParseTypeAnnotation(/* eatColon */ false);
+						node.parameterName = typePredicateVariable;
+						node.typeAnnotation = type;
+						node.asserts = false;
+						t.typeAnnotation = this.finishNode(node, 'TSTypePredicate');
+						return this.finishNode(t, 'TSTypeAnnotation');
+					}
 
 					const asserts = !!this.tsTryParse(this.tsParseTypePredicateAsserts.bind(this));
 
@@ -1406,10 +1417,12 @@ export function tsPlugin(options?: {
 						return this.finishNode(t, 'TSTypeAnnotation');
 					}
 
-					const typePredicateVariable =
-						this.tsIsIdentifier() && this.tsTryParse(this.tsParseTypePredicatePrefix.bind(this));
+					const assertedTypePredicateVariable =
+						asserts &&
+						this.tsIsIdentifier() &&
+						this.tsTryParse(this.tsParseTypePredicatePrefix.bind(this));
 
-					if (!typePredicateVariable) {
+					if (!assertedTypePredicateVariable) {
 						if (!asserts) {
 							// : type
 							return this.tsParseTypeAnnotation(/* eatColon */ false, t);
@@ -1425,7 +1438,7 @@ export function tsPlugin(options?: {
 
 					// : asserts foo is type
 					const type = this.tsParseTypeAnnotation(/* eatColon */ false);
-					node.parameterName = typePredicateVariable;
+					node.parameterName = assertedTypePredicateVariable;
 					node.typeAnnotation = type;
 					node.asserts = asserts;
 					t.typeAnnotation = this.finishNode(node, 'TSTypePredicate');

--- a/test/type_predicate_asserts_parameter/expected.json
+++ b/test/type_predicate_asserts_parameter/expected.json
@@ -1,0 +1,193 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 51,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 2,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "FunctionDeclaration",
+			"start": 0,
+			"end": 50,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 50
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 9,
+				"end": 10,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 9
+					},
+					"end": {
+						"line": 1,
+						"column": 10
+					}
+				},
+				"name": "f"
+			},
+			"expression": false,
+			"generator": false,
+			"async": false,
+			"params": [
+				{
+					"type": "Identifier",
+					"start": 11,
+					"end": 27,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 11
+						},
+						"end": {
+							"line": 1,
+							"column": 27
+						}
+					},
+					"name": "asserts",
+					"typeAnnotation": {
+						"type": "TSTypeAnnotation",
+						"start": 18,
+						"end": 27,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 18
+							},
+							"end": {
+								"line": 1,
+								"column": 27
+							}
+						},
+						"typeAnnotation": {
+							"type": "TSUnknownKeyword",
+							"start": 20,
+							"end": 27,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 20
+								},
+								"end": {
+									"line": 1,
+									"column": 27
+								}
+							}
+						}
+					}
+				}
+			],
+			"returnType": {
+				"type": "TSTypeAnnotation",
+				"start": 28,
+				"end": 47,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 28
+					},
+					"end": {
+						"line": 1,
+						"column": 47
+					}
+				},
+				"typeAnnotation": {
+					"type": "TSTypePredicate",
+					"start": 30,
+					"end": 47,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 30
+						},
+						"end": {
+							"line": 1,
+							"column": 47
+						}
+					},
+					"parameterName": {
+						"type": "Identifier",
+						"start": 30,
+						"end": 37,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 30
+							},
+							"end": {
+								"line": 1,
+								"column": 37
+							}
+						},
+						"name": "asserts"
+					},
+					"typeAnnotation": {
+						"type": "TSTypeAnnotation",
+						"start": 41,
+						"end": 47,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 41
+							},
+							"end": {
+								"line": 1,
+								"column": 47
+							}
+						},
+						"typeAnnotation": {
+							"type": "TSStringKeyword",
+							"start": 41,
+							"end": 47,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 41
+								},
+								"end": {
+									"line": 1,
+									"column": 47
+								}
+							}
+						}
+					},
+					"asserts": false
+				}
+			},
+			"body": {
+				"type": "BlockStatement",
+				"start": 48,
+				"end": 50,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 48
+					},
+					"end": {
+						"line": 1,
+						"column": 50
+					}
+				},
+				"body": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/type_predicate_asserts_parameter/input.ts
+++ b/test/type_predicate_asserts_parameter/input.ts
@@ -1,0 +1,1 @@
+function f(asserts: unknown): asserts is string {}


### PR DESCRIPTION
Recognize ordinary type predicates before treating asserts as the assertion signature modifier.

Add a minimal parser fixture for `function f(asserts: unknown): asserts is string`.

- Close: #64 