### PR TITLE
fix: parse type arguments in decorator expressions

### DIFF
--- a/.changeset/calm-decorators-parse.md
+++ b/.changeset/calm-decorators-parse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: parse type arguments on decorators

--- a/src/index.ts
+++ b/src/index.ts
@@ -4561,6 +4561,30 @@ export function tsPlugin(options?: {
 				return elts;
 			}
 
+			parseMaybeDecoratorArguments(expr: any): any {
+				const typeArguments =
+					this.tsMatchLeftRelational() || this.match(tt.bitShift)
+						? this.tsParseTypeArgumentsInExpression()
+						: undefined;
+
+				if (this.eat(tt.parenL)) {
+					const node = this.startNodeAtNode(expr);
+					node.callee = expr;
+					node.arguments = this.parseExprList(tt.parenR, false);
+					if (typeArguments) node.typeArguments = typeArguments;
+					return this.finishNode(node, 'CallExpression');
+				}
+
+				if (typeArguments) {
+					const node = this.startNodeAtNode(expr);
+					node.expression = expr;
+					node.typeArguments = typeArguments;
+					return this.finishNode(node, 'TSInstantiationExpression');
+				}
+
+				return expr;
+			}
+
 			parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit) {
 				let _optionalChained = optionalChained;
 				// --- start extend parseSubscript

--- a/test/decorator_type_arguments/expected.json
+++ b/test/decorator_type_arguments/expected.json
@@ -1,0 +1,1123 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 200,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 15,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "VariableDeclaration",
+			"start": 0,
+			"end": 107,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 5,
+					"column": 1
+				}
+			},
+			"declarations": [
+				{
+					"type": "VariableDeclarator",
+					"start": 4,
+					"end": 107,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 4
+						},
+						"end": {
+							"line": 5,
+							"column": 1
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 4,
+						"end": 5,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 4
+							},
+							"end": {
+								"line": 1,
+								"column": 5
+							}
+						},
+						"name": "a"
+					},
+					"init": {
+						"type": "ObjectExpression",
+						"start": 8,
+						"end": 107,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 8
+							},
+							"end": {
+								"line": 5,
+								"column": 1
+							}
+						},
+						"properties": [
+							{
+								"type": "Property",
+								"start": 12,
+								"end": 36,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 2
+									},
+									"end": {
+										"line": 2,
+										"column": 26
+									}
+								},
+								"method": false,
+								"shorthand": false,
+								"computed": false,
+								"key": {
+									"type": "Identifier",
+									"start": 12,
+									"end": 14,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 2
+										},
+										"end": {
+											"line": 2,
+											"column": 4
+										}
+									},
+									"name": "b1"
+								},
+								"value": {
+									"type": "ArrowFunctionExpression",
+									"start": 16,
+									"end": 36,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 6
+										},
+										"end": {
+											"line": 2,
+											"column": 26
+										}
+									},
+									"id": null,
+									"expression": false,
+									"generator": false,
+									"async": false,
+									"params": [
+										{
+											"type": "Identifier",
+											"start": 20,
+											"end": 29,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 10
+												},
+												"end": {
+													"line": 2,
+													"column": 19
+												}
+											},
+											"name": "args",
+											"typeAnnotation": {
+												"type": "TSTypeAnnotation",
+												"start": 24,
+												"end": 29,
+												"loc": {
+													"start": {
+														"line": 2,
+														"column": 14
+													},
+													"end": {
+														"line": 2,
+														"column": 19
+													}
+												},
+												"typeAnnotation": {
+													"type": "TSAnyKeyword",
+													"start": 26,
+													"end": 29,
+													"loc": {
+														"start": {
+															"line": 2,
+															"column": 16
+														},
+														"end": {
+															"line": 2,
+															"column": 19
+														}
+													}
+												}
+											}
+										}
+									],
+									"body": {
+										"type": "BlockStatement",
+										"start": 34,
+										"end": 36,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 24
+											},
+											"end": {
+												"line": 2,
+												"column": 26
+											}
+										},
+										"body": []
+									},
+									"typeParameters": {
+										"type": "TSTypeParameterDeclaration",
+										"start": 16,
+										"end": 19,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 6
+											},
+											"end": {
+												"line": 2,
+												"column": 9
+											}
+										},
+										"params": [
+											{
+												"type": "TSTypeParameter",
+												"start": 17,
+												"end": 18,
+												"loc": {
+													"start": {
+														"line": 2,
+														"column": 7
+													},
+													"end": {
+														"line": 2,
+														"column": 8
+													}
+												},
+												"name": "T"
+											}
+										]
+									}
+								},
+								"kind": "init"
+							},
+							{
+								"type": "Property",
+								"start": 40,
+								"end": 70,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 2
+									},
+									"end": {
+										"line": 3,
+										"column": 32
+									}
+								},
+								"method": false,
+								"shorthand": false,
+								"computed": false,
+								"key": {
+									"type": "Identifier",
+									"start": 40,
+									"end": 42,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 2
+										},
+										"end": {
+											"line": 3,
+											"column": 4
+										}
+									},
+									"name": "b2"
+								},
+								"value": {
+									"type": "ArrowFunctionExpression",
+									"start": 44,
+									"end": 70,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 6
+										},
+										"end": {
+											"line": 3,
+											"column": 32
+										}
+									},
+									"id": null,
+									"expression": true,
+									"generator": false,
+									"async": false,
+									"params": [],
+									"body": {
+										"type": "ArrowFunctionExpression",
+										"start": 53,
+										"end": 70,
+										"loc": {
+											"start": {
+												"line": 3,
+												"column": 15
+											},
+											"end": {
+												"line": 3,
+												"column": 32
+											}
+										},
+										"id": null,
+										"expression": false,
+										"generator": false,
+										"async": false,
+										"params": [
+											{
+												"type": "Identifier",
+												"start": 54,
+												"end": 63,
+												"loc": {
+													"start": {
+														"line": 3,
+														"column": 16
+													},
+													"end": {
+														"line": 3,
+														"column": 25
+													}
+												},
+												"name": "args",
+												"typeAnnotation": {
+													"type": "TSTypeAnnotation",
+													"start": 58,
+													"end": 63,
+													"loc": {
+														"start": {
+															"line": 3,
+															"column": 20
+														},
+														"end": {
+															"line": 3,
+															"column": 25
+														}
+													},
+													"typeAnnotation": {
+														"type": "TSAnyKeyword",
+														"start": 60,
+														"end": 63,
+														"loc": {
+															"start": {
+																"line": 3,
+																"column": 22
+															},
+															"end": {
+																"line": 3,
+																"column": 25
+															}
+														}
+													}
+												}
+											}
+										],
+										"body": {
+											"type": "BlockStatement",
+											"start": 68,
+											"end": 70,
+											"loc": {
+												"start": {
+													"line": 3,
+													"column": 30
+												},
+												"end": {
+													"line": 3,
+													"column": 32
+												}
+											},
+											"body": []
+										}
+									},
+									"typeParameters": {
+										"type": "TSTypeParameterDeclaration",
+										"start": 44,
+										"end": 47,
+										"loc": {
+											"start": {
+												"line": 3,
+												"column": 6
+											},
+											"end": {
+												"line": 3,
+												"column": 9
+											}
+										},
+										"params": [
+											{
+												"type": "TSTypeParameter",
+												"start": 45,
+												"end": 46,
+												"loc": {
+													"start": {
+														"line": 3,
+														"column": 7
+													},
+													"end": {
+														"line": 3,
+														"column": 8
+													}
+												},
+												"name": "T"
+											}
+										]
+									}
+								},
+								"kind": "init"
+							},
+							{
+								"type": "Property",
+								"start": 74,
+								"end": 104,
+								"loc": {
+									"start": {
+										"line": 4,
+										"column": 2
+									},
+									"end": {
+										"line": 4,
+										"column": 32
+									}
+								},
+								"method": false,
+								"shorthand": false,
+								"computed": false,
+								"key": {
+									"type": "Identifier",
+									"start": 74,
+									"end": 76,
+									"loc": {
+										"start": {
+											"line": 4,
+											"column": 2
+										},
+										"end": {
+											"line": 4,
+											"column": 4
+										}
+									},
+									"name": "b3"
+								},
+								"value": {
+									"type": "ArrowFunctionExpression",
+									"start": 78,
+									"end": 104,
+									"loc": {
+										"start": {
+											"line": 4,
+											"column": 6
+										},
+										"end": {
+											"line": 4,
+											"column": 32
+										}
+									},
+									"id": null,
+									"expression": true,
+									"generator": false,
+									"async": false,
+									"params": [],
+									"body": {
+										"type": "ArrowFunctionExpression",
+										"start": 87,
+										"end": 104,
+										"loc": {
+											"start": {
+												"line": 4,
+												"column": 15
+											},
+											"end": {
+												"line": 4,
+												"column": 32
+											}
+										},
+										"id": null,
+										"expression": false,
+										"generator": false,
+										"async": false,
+										"params": [
+											{
+												"type": "Identifier",
+												"start": 88,
+												"end": 97,
+												"loc": {
+													"start": {
+														"line": 4,
+														"column": 16
+													},
+													"end": {
+														"line": 4,
+														"column": 25
+													}
+												},
+												"name": "args",
+												"typeAnnotation": {
+													"type": "TSTypeAnnotation",
+													"start": 92,
+													"end": 97,
+													"loc": {
+														"start": {
+															"line": 4,
+															"column": 20
+														},
+														"end": {
+															"line": 4,
+															"column": 25
+														}
+													},
+													"typeAnnotation": {
+														"type": "TSAnyKeyword",
+														"start": 94,
+														"end": 97,
+														"loc": {
+															"start": {
+																"line": 4,
+																"column": 22
+															},
+															"end": {
+																"line": 4,
+																"column": 25
+															}
+														}
+													}
+												}
+											}
+										],
+										"body": {
+											"type": "BlockStatement",
+											"start": 102,
+											"end": 104,
+											"loc": {
+												"start": {
+													"line": 4,
+													"column": 30
+												},
+												"end": {
+													"line": 4,
+													"column": 32
+												}
+											},
+											"body": []
+										}
+									},
+									"typeParameters": {
+										"type": "TSTypeParameterDeclaration",
+										"start": 78,
+										"end": 81,
+										"loc": {
+											"start": {
+												"line": 4,
+												"column": 6
+											},
+											"end": {
+												"line": 4,
+												"column": 9
+											}
+										},
+										"params": [
+											{
+												"type": "TSTypeParameter",
+												"start": 79,
+												"end": 80,
+												"loc": {
+													"start": {
+														"line": 4,
+														"column": 7
+													},
+													"end": {
+														"line": 4,
+														"column": 8
+													}
+												},
+												"name": "T"
+											}
+										]
+									}
+								},
+								"kind": "init"
+							}
+						]
+					}
+				}
+			],
+			"kind": "let"
+		},
+		{
+			"type": "ClassDeclaration",
+			"start": 109,
+			"end": 134,
+			"loc": {
+				"start": {
+					"line": 7,
+					"column": 0
+				},
+				"end": {
+					"line": 8,
+					"column": 11
+				}
+			},
+			"decorators": [
+				{
+					"type": "Decorator",
+					"start": 109,
+					"end": 122,
+					"loc": {
+						"start": {
+							"line": 7,
+							"column": 0
+						},
+						"end": {
+							"line": 7,
+							"column": 13
+						}
+					},
+					"expression": {
+						"type": "TSInstantiationExpression",
+						"start": 110,
+						"end": 122,
+						"loc": {
+							"start": {
+								"line": 7,
+								"column": 1
+							},
+							"end": {
+								"line": 7,
+								"column": 13
+							}
+						},
+						"expression": {
+							"type": "MemberExpression",
+							"start": 110,
+							"end": 114,
+							"loc": {
+								"start": {
+									"line": 7,
+									"column": 1
+								},
+								"end": {
+									"line": 7,
+									"column": 5
+								}
+							},
+							"object": {
+								"type": "Identifier",
+								"start": 110,
+								"end": 111,
+								"loc": {
+									"start": {
+										"line": 7,
+										"column": 1
+									},
+									"end": {
+										"line": 7,
+										"column": 2
+									}
+								},
+								"name": "a"
+							},
+							"property": {
+								"type": "Identifier",
+								"start": 112,
+								"end": 114,
+								"loc": {
+									"start": {
+										"line": 7,
+										"column": 3
+									},
+									"end": {
+										"line": 7,
+										"column": 5
+									}
+								},
+								"name": "b1"
+							},
+							"computed": false
+						},
+						"typeArguments": {
+							"type": "TSTypeParameterInstantiation",
+							"start": 114,
+							"end": 122,
+							"loc": {
+								"start": {
+									"line": 7,
+									"column": 5
+								},
+								"end": {
+									"line": 7,
+									"column": 13
+								}
+							},
+							"params": [
+								{
+									"type": "TSNumberKeyword",
+									"start": 115,
+									"end": 121,
+									"loc": {
+										"start": {
+											"line": 7,
+											"column": 6
+										},
+										"end": {
+											"line": 7,
+											"column": 12
+										}
+									}
+								}
+							]
+						}
+					}
+				}
+			],
+			"id": {
+				"type": "Identifier",
+				"start": 129,
+				"end": 131,
+				"loc": {
+					"start": {
+						"line": 8,
+						"column": 6
+					},
+					"end": {
+						"line": 8,
+						"column": 8
+					}
+				},
+				"name": "C1"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 132,
+				"end": 134,
+				"loc": {
+					"start": {
+						"line": 8,
+						"column": 9
+					},
+					"end": {
+						"line": 8,
+						"column": 11
+					}
+				},
+				"body": []
+			}
+		},
+		{
+			"type": "ClassDeclaration",
+			"start": 136,
+			"end": 163,
+			"loc": {
+				"start": {
+					"line": 10,
+					"column": 0
+				},
+				"end": {
+					"line": 11,
+					"column": 11
+				}
+			},
+			"decorators": [
+				{
+					"type": "Decorator",
+					"start": 136,
+					"end": 151,
+					"loc": {
+						"start": {
+							"line": 10,
+							"column": 0
+						},
+						"end": {
+							"line": 10,
+							"column": 15
+						}
+					},
+					"expression": {
+						"type": "CallExpression",
+						"start": 137,
+						"end": 151,
+						"loc": {
+							"start": {
+								"line": 10,
+								"column": 1
+							},
+							"end": {
+								"line": 10,
+								"column": 15
+							}
+						},
+						"callee": {
+							"type": "MemberExpression",
+							"start": 137,
+							"end": 141,
+							"loc": {
+								"start": {
+									"line": 10,
+									"column": 1
+								},
+								"end": {
+									"line": 10,
+									"column": 5
+								}
+							},
+							"object": {
+								"type": "Identifier",
+								"start": 137,
+								"end": 138,
+								"loc": {
+									"start": {
+										"line": 10,
+										"column": 1
+									},
+									"end": {
+										"line": 10,
+										"column": 2
+									}
+								},
+								"name": "a"
+							},
+							"property": {
+								"type": "Identifier",
+								"start": 139,
+								"end": 141,
+								"loc": {
+									"start": {
+										"line": 10,
+										"column": 3
+									},
+									"end": {
+										"line": 10,
+										"column": 5
+									}
+								},
+								"name": "b2"
+							},
+							"computed": false
+						},
+						"arguments": [],
+						"typeArguments": {
+							"type": "TSTypeParameterInstantiation",
+							"start": 141,
+							"end": 149,
+							"loc": {
+								"start": {
+									"line": 10,
+									"column": 5
+								},
+								"end": {
+									"line": 10,
+									"column": 13
+								}
+							},
+							"params": [
+								{
+									"type": "TSNumberKeyword",
+									"start": 142,
+									"end": 148,
+									"loc": {
+										"start": {
+											"line": 10,
+											"column": 6
+										},
+										"end": {
+											"line": 10,
+											"column": 12
+										}
+									}
+								}
+							]
+						}
+					}
+				}
+			],
+			"id": {
+				"type": "Identifier",
+				"start": 158,
+				"end": 160,
+				"loc": {
+					"start": {
+						"line": 11,
+						"column": 6
+					},
+					"end": {
+						"line": 11,
+						"column": 8
+					}
+				},
+				"name": "C2"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 161,
+				"end": 163,
+				"loc": {
+					"start": {
+						"line": 11,
+						"column": 9
+					},
+					"end": {
+						"line": 11,
+						"column": 11
+					}
+				},
+				"body": []
+			}
+		},
+		{
+			"type": "ClassDeclaration",
+			"start": 165,
+			"end": 199,
+			"loc": {
+				"start": {
+					"line": 13,
+					"column": 0
+				},
+				"end": {
+					"line": 14,
+					"column": 11
+				}
+			},
+			"decorators": [
+				{
+					"type": "Decorator",
+					"start": 165,
+					"end": 187,
+					"loc": {
+						"start": {
+							"line": 13,
+							"column": 0
+						},
+						"end": {
+							"line": 13,
+							"column": 22
+						}
+					},
+					"expression": {
+						"type": "CallExpression",
+						"start": 166,
+						"end": 187,
+						"loc": {
+							"start": {
+								"line": 13,
+								"column": 1
+							},
+							"end": {
+								"line": 13,
+								"column": 22
+							}
+						},
+						"callee": {
+							"type": "MemberExpression",
+							"start": 166,
+							"end": 170,
+							"loc": {
+								"start": {
+									"line": 13,
+									"column": 1
+								},
+								"end": {
+									"line": 13,
+									"column": 5
+								}
+							},
+							"object": {
+								"type": "Identifier",
+								"start": 166,
+								"end": 167,
+								"loc": {
+									"start": {
+										"line": 13,
+										"column": 1
+									},
+									"end": {
+										"line": 13,
+										"column": 2
+									}
+								},
+								"name": "a"
+							},
+							"property": {
+								"type": "Identifier",
+								"start": 168,
+								"end": 170,
+								"loc": {
+									"start": {
+										"line": 13,
+										"column": 3
+									},
+									"end": {
+										"line": 13,
+										"column": 5
+									}
+								},
+								"name": "b3"
+							},
+							"computed": false
+						},
+						"arguments": [],
+						"typeArguments": {
+							"type": "TSTypeParameterInstantiation",
+							"start": 170,
+							"end": 185,
+							"loc": {
+								"start": {
+									"line": 13,
+									"column": 5
+								},
+								"end": {
+									"line": 13,
+									"column": 20
+								}
+							},
+							"params": [
+								{
+									"type": "TSFunctionType",
+									"start": 171,
+									"end": 184,
+									"loc": {
+										"start": {
+											"line": 13,
+											"column": 6
+										},
+										"end": {
+											"line": 13,
+											"column": 19
+										}
+									},
+									"typeParameters": {
+										"type": "TSTypeParameterDeclaration",
+										"start": 171,
+										"end": 174,
+										"loc": {
+											"start": {
+												"line": 13,
+												"column": 6
+											},
+											"end": {
+												"line": 13,
+												"column": 9
+											}
+										},
+										"params": [
+											{
+												"type": "TSTypeParameter",
+												"start": 172,
+												"end": 173,
+												"loc": {
+													"start": {
+														"line": 13,
+														"column": 7
+													},
+													"end": {
+														"line": 13,
+														"column": 8
+													}
+												},
+												"name": "T"
+											}
+										]
+									},
+									"parameters": [],
+									"typeAnnotation": {
+										"type": "TSTypeAnnotation",
+										"start": 177,
+										"end": 184,
+										"loc": {
+											"start": {
+												"line": 13,
+												"column": 12
+											},
+											"end": {
+												"line": 13,
+												"column": 19
+											}
+										},
+										"typeAnnotation": {
+											"type": "TSVoidKeyword",
+											"start": 180,
+											"end": 184,
+											"loc": {
+												"start": {
+													"line": 13,
+													"column": 15
+												},
+												"end": {
+													"line": 13,
+													"column": 19
+												}
+											}
+										}
+									}
+								}
+							]
+						}
+					}
+				}
+			],
+			"id": {
+				"type": "Identifier",
+				"start": 194,
+				"end": 196,
+				"loc": {
+					"start": {
+						"line": 14,
+						"column": 6
+					},
+					"end": {
+						"line": 14,
+						"column": 8
+					}
+				},
+				"name": "C3"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 197,
+				"end": 199,
+				"loc": {
+					"start": {
+						"line": 14,
+						"column": 9
+					},
+					"end": {
+						"line": 14,
+						"column": 11
+					}
+				},
+				"body": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/decorator_type_arguments/expected.json
+++ b/test/decorator_type_arguments/expected.json
@@ -1,14 +1,14 @@
 {
 	"type": "Program",
 	"start": 0,
-	"end": 200,
+	"end": 313,
 	"loc": {
 		"start": {
 			"line": 1,
 			"column": 0
 		},
 		"end": {
-			"line": 15,
+			"line": 24,
 			"column": 0
 		}
 	},
@@ -1117,6 +1117,606 @@
 				},
 				"body": []
 			}
+		},
+		{
+			"type": "ExportNamedDeclaration",
+			"start": 215,
+			"end": 233,
+			"loc": {
+				"start": {
+					"line": 17,
+					"column": 0
+				},
+				"end": {
+					"line": 17,
+					"column": 18
+				}
+			},
+			"exportKind": "value",
+			"declaration": {
+				"type": "ClassDeclaration",
+				"start": 201,
+				"end": 233,
+				"loc": {
+					"start": {
+						"line": 16,
+						"column": 0
+					},
+					"end": {
+						"line": 17,
+						"column": 18
+					}
+				},
+				"decorators": [
+					{
+						"type": "Decorator",
+						"start": 201,
+						"end": 214,
+						"loc": {
+							"start": {
+								"line": 16,
+								"column": 0
+							},
+							"end": {
+								"line": 16,
+								"column": 13
+							}
+						},
+						"expression": {
+							"type": "TSInstantiationExpression",
+							"start": 202,
+							"end": 214,
+							"loc": {
+								"start": {
+									"line": 16,
+									"column": 1
+								},
+								"end": {
+									"line": 16,
+									"column": 13
+								}
+							},
+							"expression": {
+								"type": "MemberExpression",
+								"start": 202,
+								"end": 206,
+								"loc": {
+									"start": {
+										"line": 16,
+										"column": 1
+									},
+									"end": {
+										"line": 16,
+										"column": 5
+									}
+								},
+								"object": {
+									"type": "Identifier",
+									"start": 202,
+									"end": 203,
+									"loc": {
+										"start": {
+											"line": 16,
+											"column": 1
+										},
+										"end": {
+											"line": 16,
+											"column": 2
+										}
+									},
+									"name": "a"
+								},
+								"property": {
+									"type": "Identifier",
+									"start": 204,
+									"end": 206,
+									"loc": {
+										"start": {
+											"line": 16,
+											"column": 3
+										},
+										"end": {
+											"line": 16,
+											"column": 5
+										}
+									},
+									"name": "b1"
+								},
+								"computed": false
+							},
+							"typeArguments": {
+								"type": "TSTypeParameterInstantiation",
+								"start": 206,
+								"end": 214,
+								"loc": {
+									"start": {
+										"line": 16,
+										"column": 5
+									},
+									"end": {
+										"line": 16,
+										"column": 13
+									}
+								},
+								"params": [
+									{
+										"type": "TSNumberKeyword",
+										"start": 207,
+										"end": 213,
+										"loc": {
+											"start": {
+												"line": 16,
+												"column": 6
+											},
+											"end": {
+												"line": 16,
+												"column": 12
+											}
+										}
+									}
+								]
+							}
+						}
+					}
+				],
+				"id": {
+					"type": "Identifier",
+					"start": 228,
+					"end": 230,
+					"loc": {
+						"start": {
+							"line": 17,
+							"column": 13
+						},
+						"end": {
+							"line": 17,
+							"column": 15
+						}
+					},
+					"name": "C4"
+				},
+				"superClass": null,
+				"body": {
+					"type": "ClassBody",
+					"start": 231,
+					"end": 233,
+					"loc": {
+						"start": {
+							"line": 17,
+							"column": 16
+						},
+						"end": {
+							"line": 17,
+							"column": 18
+						}
+					},
+					"body": []
+				}
+			},
+			"specifiers": [],
+			"source": null
+		},
+		{
+			"type": "ExportNamedDeclaration",
+			"start": 251,
+			"end": 269,
+			"loc": {
+				"start": {
+					"line": 20,
+					"column": 0
+				},
+				"end": {
+					"line": 20,
+					"column": 18
+				}
+			},
+			"exportKind": "value",
+			"declaration": {
+				"type": "ClassDeclaration",
+				"start": 235,
+				"end": 269,
+				"loc": {
+					"start": {
+						"line": 19,
+						"column": 0
+					},
+					"end": {
+						"line": 20,
+						"column": 18
+					}
+				},
+				"decorators": [
+					{
+						"type": "Decorator",
+						"start": 235,
+						"end": 250,
+						"loc": {
+							"start": {
+								"line": 19,
+								"column": 0
+							},
+							"end": {
+								"line": 19,
+								"column": 15
+							}
+						},
+						"expression": {
+							"type": "CallExpression",
+							"start": 236,
+							"end": 250,
+							"loc": {
+								"start": {
+									"line": 19,
+									"column": 1
+								},
+								"end": {
+									"line": 19,
+									"column": 15
+								}
+							},
+							"callee": {
+								"type": "MemberExpression",
+								"start": 236,
+								"end": 240,
+								"loc": {
+									"start": {
+										"line": 19,
+										"column": 1
+									},
+									"end": {
+										"line": 19,
+										"column": 5
+									}
+								},
+								"object": {
+									"type": "Identifier",
+									"start": 236,
+									"end": 237,
+									"loc": {
+										"start": {
+											"line": 19,
+											"column": 1
+										},
+										"end": {
+											"line": 19,
+											"column": 2
+										}
+									},
+									"name": "a"
+								},
+								"property": {
+									"type": "Identifier",
+									"start": 238,
+									"end": 240,
+									"loc": {
+										"start": {
+											"line": 19,
+											"column": 3
+										},
+										"end": {
+											"line": 19,
+											"column": 5
+										}
+									},
+									"name": "b2"
+								},
+								"computed": false
+							},
+							"arguments": [],
+							"typeArguments": {
+								"type": "TSTypeParameterInstantiation",
+								"start": 240,
+								"end": 248,
+								"loc": {
+									"start": {
+										"line": 19,
+										"column": 5
+									},
+									"end": {
+										"line": 19,
+										"column": 13
+									}
+								},
+								"params": [
+									{
+										"type": "TSNumberKeyword",
+										"start": 241,
+										"end": 247,
+										"loc": {
+											"start": {
+												"line": 19,
+												"column": 6
+											},
+											"end": {
+												"line": 19,
+												"column": 12
+											}
+										}
+									}
+								]
+							}
+						}
+					}
+				],
+				"id": {
+					"type": "Identifier",
+					"start": 264,
+					"end": 266,
+					"loc": {
+						"start": {
+							"line": 20,
+							"column": 13
+						},
+						"end": {
+							"line": 20,
+							"column": 15
+						}
+					},
+					"name": "C5"
+				},
+				"superClass": null,
+				"body": {
+					"type": "ClassBody",
+					"start": 267,
+					"end": 269,
+					"loc": {
+						"start": {
+							"line": 20,
+							"column": 16
+						},
+						"end": {
+							"line": 20,
+							"column": 18
+						}
+					},
+					"body": []
+				}
+			},
+			"specifiers": [],
+			"source": null
+		},
+		{
+			"type": "ExportNamedDeclaration",
+			"start": 294,
+			"end": 312,
+			"loc": {
+				"start": {
+					"line": 23,
+					"column": 0
+				},
+				"end": {
+					"line": 23,
+					"column": 18
+				}
+			},
+			"exportKind": "value",
+			"declaration": {
+				"type": "ClassDeclaration",
+				"start": 271,
+				"end": 312,
+				"loc": {
+					"start": {
+						"line": 22,
+						"column": 0
+					},
+					"end": {
+						"line": 23,
+						"column": 18
+					}
+				},
+				"decorators": [
+					{
+						"type": "Decorator",
+						"start": 271,
+						"end": 293,
+						"loc": {
+							"start": {
+								"line": 22,
+								"column": 0
+							},
+							"end": {
+								"line": 22,
+								"column": 22
+							}
+						},
+						"expression": {
+							"type": "CallExpression",
+							"start": 272,
+							"end": 293,
+							"loc": {
+								"start": {
+									"line": 22,
+									"column": 1
+								},
+								"end": {
+									"line": 22,
+									"column": 22
+								}
+							},
+							"callee": {
+								"type": "MemberExpression",
+								"start": 272,
+								"end": 276,
+								"loc": {
+									"start": {
+										"line": 22,
+										"column": 1
+									},
+									"end": {
+										"line": 22,
+										"column": 5
+									}
+								},
+								"object": {
+									"type": "Identifier",
+									"start": 272,
+									"end": 273,
+									"loc": {
+										"start": {
+											"line": 22,
+											"column": 1
+										},
+										"end": {
+											"line": 22,
+											"column": 2
+										}
+									},
+									"name": "a"
+								},
+								"property": {
+									"type": "Identifier",
+									"start": 274,
+									"end": 276,
+									"loc": {
+										"start": {
+											"line": 22,
+											"column": 3
+										},
+										"end": {
+											"line": 22,
+											"column": 5
+										}
+									},
+									"name": "b3"
+								},
+								"computed": false
+							},
+							"arguments": [],
+							"typeArguments": {
+								"type": "TSTypeParameterInstantiation",
+								"start": 276,
+								"end": 291,
+								"loc": {
+									"start": {
+										"line": 22,
+										"column": 5
+									},
+									"end": {
+										"line": 22,
+										"column": 20
+									}
+								},
+								"params": [
+									{
+										"type": "TSFunctionType",
+										"start": 277,
+										"end": 290,
+										"loc": {
+											"start": {
+												"line": 22,
+												"column": 6
+											},
+											"end": {
+												"line": 22,
+												"column": 19
+											}
+										},
+										"typeParameters": {
+											"type": "TSTypeParameterDeclaration",
+											"start": 277,
+											"end": 280,
+											"loc": {
+												"start": {
+													"line": 22,
+													"column": 6
+												},
+												"end": {
+													"line": 22,
+													"column": 9
+												}
+											},
+											"params": [
+												{
+													"type": "TSTypeParameter",
+													"start": 278,
+													"end": 279,
+													"loc": {
+														"start": {
+															"line": 22,
+															"column": 7
+														},
+														"end": {
+															"line": 22,
+															"column": 8
+														}
+													},
+													"name": "T"
+												}
+											]
+										},
+										"parameters": [],
+										"typeAnnotation": {
+											"type": "TSTypeAnnotation",
+											"start": 283,
+											"end": 290,
+											"loc": {
+												"start": {
+													"line": 22,
+													"column": 12
+												},
+												"end": {
+													"line": 22,
+													"column": 19
+												}
+											},
+											"typeAnnotation": {
+												"type": "TSVoidKeyword",
+												"start": 286,
+												"end": 290,
+												"loc": {
+													"start": {
+														"line": 22,
+														"column": 15
+													},
+													"end": {
+														"line": 22,
+														"column": 19
+													}
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					}
+				],
+				"id": {
+					"type": "Identifier",
+					"start": 307,
+					"end": 309,
+					"loc": {
+						"start": {
+							"line": 23,
+							"column": 13
+						},
+						"end": {
+							"line": 23,
+							"column": 15
+						}
+					},
+					"name": "C6"
+				},
+				"superClass": null,
+				"body": {
+					"type": "ClassBody",
+					"start": 310,
+					"end": 312,
+					"loc": {
+						"start": {
+							"line": 23,
+							"column": 16
+						},
+						"end": {
+							"line": 23,
+							"column": 18
+						}
+					},
+					"body": []
+				}
+			},
+			"specifiers": [],
+			"source": null
 		}
 	],
 	"sourceType": "module"

--- a/test/decorator_type_arguments/input.ts
+++ b/test/decorator_type_arguments/input.ts
@@ -1,0 +1,14 @@
+let a = {
+  b1: <T>(args: any) => {},
+  b2: <T>() => (args: any) => {},
+  b3: <T>() => (args: any) => {},
+}
+
+@a.b1<number>
+class C1 {}
+
+@a.b2<number>()
+class C2 {}
+
+@a.b3<<T>() => void>()
+class C3 {}

--- a/test/decorator_type_arguments/input.ts
+++ b/test/decorator_type_arguments/input.ts
@@ -12,3 +12,12 @@ class C2 {}
 
 @a.b3<<T>() => void>()
 class C3 {}
+
+@a.b1<number>
+export class C4 {}
+
+@a.b2<number>()
+export class C5 {}
+
+@a.b3<<T>() => void>()
+export class C6 {}


### PR DESCRIPTION
Parse unparenthesized type arguments before optional decorator call arguments, preserving them on instantiation and call expressions.

Add regression coverage for member decorators and nested generic function types that tokenize as a left shift.

- Close #46