### PR TITLE
fix: parse generic arrows after yield

### DIFF
--- a/.changeset/yield-generic-arrow.md
+++ b/.changeset/yield-generic-arrow.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Parse TypeScript expressions beginning with `<` as yield arguments.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3972,6 +3972,27 @@ export function tsPlugin(options?: {
 				// end
 			}
 
+			parseYield(forInit?: boolean): any {
+				if (!this.yieldPos) this.yieldPos = this.start;
+
+				const node = this.startNode();
+				this.next();
+				const startsTypeScriptExpression = this.tsMatchLeftRelational();
+				const hasArgument =
+					!this.match(tt.semi) &&
+					!this.canInsertSemicolon() &&
+					(this.match(tt.star) || this.type.startsExpr || startsTypeScriptExpression);
+				if (!hasArgument) {
+					node.delegate = false;
+					node.argument = null;
+					return this.finishNode(node, 'YieldExpression');
+				}
+
+				node.delegate = this.eat(tt.star);
+				node.argument = this.parseMaybeAssign(forInit);
+				return this.finishNode(node, 'YieldExpression');
+			}
+
 			parseMaybeAssignOrigin(
 				forInit?: any,
 				refDestructuringErrors?: any | null,

--- a/test/function_type_test_yield_generic_arrow/expected.json
+++ b/test/function_type_test_yield_generic_arrow/expected.json
@@ -1,0 +1,279 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 59,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 4,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "FunctionDeclaration",
+			"start": 0,
+			"end": 58,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 10,
+				"end": 18,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 10
+					},
+					"end": {
+						"line": 1,
+						"column": 18
+					}
+				},
+				"name": "generate"
+			},
+			"expression": false,
+			"generator": true,
+			"async": false,
+			"params": [],
+			"body": {
+				"type": "BlockStatement",
+				"start": 21,
+				"end": 58,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 21
+					},
+					"end": {
+						"line": 3,
+						"column": 1
+					}
+				},
+				"body": [
+					{
+						"type": "ExpressionStatement",
+						"start": 24,
+						"end": 56,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 1
+							},
+							"end": {
+								"line": 2,
+								"column": 33
+							}
+						},
+						"expression": {
+							"type": "YieldExpression",
+							"start": 24,
+							"end": 55,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 1
+								},
+								"end": {
+									"line": 2,
+									"column": 32
+								}
+							},
+							"delegate": false,
+							"argument": {
+								"type": "ArrowFunctionExpression",
+								"start": 30,
+								"end": 55,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 7
+									},
+									"end": {
+										"line": 2,
+										"column": 32
+									}
+								},
+								"returnType": {
+									"type": "TSTypeAnnotation",
+									"start": 43,
+									"end": 46,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 20
+										},
+										"end": {
+											"line": 2,
+											"column": 23
+										}
+									},
+									"typeAnnotation": {
+										"type": "TSTypeReference",
+										"start": 45,
+										"end": 46,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 22
+											},
+											"end": {
+												"line": 2,
+												"column": 23
+											}
+										},
+										"typeName": {
+											"type": "Identifier",
+											"start": 45,
+											"end": 46,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 22
+												},
+												"end": {
+													"line": 2,
+													"column": 23
+												}
+											},
+											"name": "T"
+										}
+									}
+								},
+								"id": null,
+								"expression": true,
+								"generator": false,
+								"async": false,
+								"params": [
+									{
+										"type": "Identifier",
+										"start": 34,
+										"end": 42,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 11
+											},
+											"end": {
+												"line": 2,
+												"column": 19
+											}
+										},
+										"name": "value",
+										"typeAnnotation": {
+											"type": "TSTypeAnnotation",
+											"start": 39,
+											"end": 42,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 16
+												},
+												"end": {
+													"line": 2,
+													"column": 19
+												}
+											},
+											"typeAnnotation": {
+												"type": "TSTypeReference",
+												"start": 41,
+												"end": 42,
+												"loc": {
+													"start": {
+														"line": 2,
+														"column": 18
+													},
+													"end": {
+														"line": 2,
+														"column": 19
+													}
+												},
+												"typeName": {
+													"type": "Identifier",
+													"start": 41,
+													"end": 42,
+													"loc": {
+														"start": {
+															"line": 2,
+															"column": 18
+														},
+														"end": {
+															"line": 2,
+															"column": 19
+														}
+													},
+													"name": "T"
+												}
+											}
+										}
+									}
+								],
+								"body": {
+									"type": "Identifier",
+									"start": 50,
+									"end": 55,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 27
+										},
+										"end": {
+											"line": 2,
+											"column": 32
+										}
+									},
+									"name": "value"
+								},
+								"typeParameters": {
+									"type": "TSTypeParameterDeclaration",
+									"start": 30,
+									"end": 33,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 7
+										},
+										"end": {
+											"line": 2,
+											"column": 10
+										}
+									},
+									"params": [
+										{
+											"type": "TSTypeParameter",
+											"start": 31,
+											"end": 32,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 8
+												},
+												"end": {
+													"line": 2,
+													"column": 9
+												}
+											},
+											"name": "T"
+										}
+									]
+								}
+							}
+						}
+					}
+				]
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/function_type_test_yield_generic_arrow/input.ts
+++ b/test/function_type_test_yield_generic_arrow/input.ts
@@ -1,0 +1,3 @@
+function* generate() {
+	yield <T>(value: T): T => value;
+}


### PR DESCRIPTION
Treat TypeScript expressions beginning with a left angle token as valid yield arguments before delegating to the normal assignment-expression parser.

Add a minimal generator fixture whose yield argument is a typed generic arrow.

- Close: #74 