### PR TITLE
fix: parse decorators on declared classes

### DIFF
--- a/.changeset/decorator-declare-class.md
+++ b/.changeset/decorator-declare-class.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Parse decorators on declared and declared abstract classes.

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,6 +316,17 @@ export function tsPlugin(options?: {
 				return this.ts_isContextual(tokTypes.abstract) && this.lookahead().type === tt._class;
 			}
 
+			isDeclareClass(): boolean {
+				if (!this.ts_isContextual(tokTypes.declare)) return false;
+
+				const afterDeclare = this.nextTokenStart();
+				if (this.isUnparsedContextual(afterDeclare, 'class')) return true;
+				if (!this.isUnparsedContextual(afterDeclare, 'abstract')) return false;
+
+				const afterAbstract = this.nextTokenStartSince(afterDeclare + 'abstract'.length);
+				return this.isUnparsedContextual(afterAbstract, 'class');
+			}
+
 			finishNode(node, type: string) {
 				if (node.type !== '' && node.end !== 0) {
 					return node;
@@ -911,7 +922,7 @@ export function tsPlugin(options?: {
 			}
 
 			canHaveLeadingDecorator(): boolean {
-				return this.match(tt._class) || this.isAbstractClass();
+				return this.match(tt._class) || this.isAbstractClass() || this.isDeclareClass();
 			}
 
 			eatContextual(name: string) {

--- a/test/decorators_class_declare/expected.json
+++ b/test/decorators_class_declare/expected.json
@@ -1,0 +1,183 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 63,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 6,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "ClassDeclaration",
+			"start": 0,
+			"end": 25,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 2,
+					"column": 18
+				}
+			},
+			"declare": true,
+			"decorators": [
+				{
+					"type": "Decorator",
+					"start": 0,
+					"end": 6,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 0
+						},
+						"end": {
+							"line": 1,
+							"column": 6
+						}
+					},
+					"expression": {
+						"type": "Identifier",
+						"start": 1,
+						"end": 6,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 1
+							},
+							"end": {
+								"line": 1,
+								"column": 6
+							}
+						},
+						"name": "first"
+					}
+				}
+			],
+			"id": {
+				"type": "Identifier",
+				"start": 21,
+				"end": 22,
+				"loc": {
+					"start": {
+						"line": 2,
+						"column": 14
+					},
+					"end": {
+						"line": 2,
+						"column": 15
+					}
+				},
+				"name": "A"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 23,
+				"end": 25,
+				"loc": {
+					"start": {
+						"line": 2,
+						"column": 16
+					},
+					"end": {
+						"line": 2,
+						"column": 18
+					}
+				},
+				"body": []
+			}
+		},
+		{
+			"type": "ClassDeclaration",
+			"start": 27,
+			"end": 62,
+			"loc": {
+				"start": {
+					"line": 4,
+					"column": 0
+				},
+				"end": {
+					"line": 5,
+					"column": 27
+				}
+			},
+			"abstract": true,
+			"decorators": [
+				{
+					"type": "Decorator",
+					"start": 27,
+					"end": 34,
+					"loc": {
+						"start": {
+							"line": 4,
+							"column": 0
+						},
+						"end": {
+							"line": 4,
+							"column": 7
+						}
+					},
+					"expression": {
+						"type": "Identifier",
+						"start": 28,
+						"end": 34,
+						"loc": {
+							"start": {
+								"line": 4,
+								"column": 1
+							},
+							"end": {
+								"line": 4,
+								"column": 7
+							}
+						},
+						"name": "second"
+					}
+				}
+			],
+			"id": {
+				"type": "Identifier",
+				"start": 58,
+				"end": 59,
+				"loc": {
+					"start": {
+						"line": 5,
+						"column": 23
+					},
+					"end": {
+						"line": 5,
+						"column": 24
+					}
+				},
+				"name": "B"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 60,
+				"end": 62,
+				"loc": {
+					"start": {
+						"line": 5,
+						"column": 25
+					},
+					"end": {
+						"line": 5,
+						"column": 27
+					}
+				},
+				"body": []
+			},
+			"declare": true
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/decorators_class_declare/input.ts
+++ b/test/decorators_class_declare/input.ts
@@ -1,0 +1,5 @@
+@first
+declare class A {}
+
+@second
+declare abstract class B {}


### PR DESCRIPTION
Recognize declare class and declare abstract class as valid decorator targets before parsing their modifier chain.

Add regression coverage for both ambient class forms.

- Close: #76 