### PR TITLE
fix: parse JSX spread children

### DIFF
--- a/.changeset/jsx-spread-child.md
+++ b/.changeset/jsx-spread-child.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Parse JSX spread children as `JSXSpreadChild` nodes.

--- a/src/extentions/jsx/index.ts
+++ b/src/extentions/jsx/index.ts
@@ -273,6 +273,11 @@ export default function generateJsxParser(
 		jsx_parseExpressionContainer(): any {
 			let node = this.startNode();
 			this.next();
+			if (this.eat(tt.ellipsis)) {
+				node.expression = this.parseExpression();
+				this.expect(tt.braceR);
+				return this.finishNode(node, 'JSXSpreadChild');
+			}
 			node.expression =
 				this.type === tt.braceR ? this.jsx_parseEmptyExpression() : this.parseExpression();
 			this.expect(tt.braceR);

--- a/test/jsx_spread_child/expected.json
+++ b/test/jsx_spread_child/expected.json
@@ -1,0 +1,179 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 39,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 2,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "VariableDeclaration",
+			"start": 0,
+			"end": 38,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 38
+				}
+			},
+			"declarations": [
+				{
+					"type": "VariableDeclarator",
+					"start": 6,
+					"end": 37,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 6
+						},
+						"end": {
+							"line": 1,
+							"column": 37
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 6,
+						"end": 13,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 6
+							},
+							"end": {
+								"line": 1,
+								"column": 13
+							}
+						},
+						"name": "element"
+					},
+					"init": {
+						"type": "JSXElement",
+						"start": 16,
+						"end": 37,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 16
+							},
+							"end": {
+								"line": 1,
+								"column": 37
+							}
+						},
+						"openingElement": {
+							"type": "JSXOpeningElement",
+							"start": 16,
+							"end": 21,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 16
+								},
+								"end": {
+									"line": 1,
+									"column": 21
+								}
+							},
+							"name": {
+								"type": "JSXIdentifier",
+								"start": 17,
+								"end": 20,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 17
+									},
+									"end": {
+										"line": 1,
+										"column": 20
+									}
+								},
+								"name": "div"
+							},
+							"attributes": [],
+							"selfClosing": false
+						},
+						"closingElement": {
+							"type": "JSXClosingElement",
+							"start": 31,
+							"end": 37,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 31
+								},
+								"end": {
+									"line": 1,
+									"column": 37
+								}
+							},
+							"name": {
+								"type": "JSXIdentifier",
+								"start": 33,
+								"end": 36,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 33
+									},
+									"end": {
+										"line": 1,
+										"column": 36
+									}
+								},
+								"name": "div"
+							}
+						},
+						"children": [
+							{
+								"type": "JSXSpreadChild",
+								"start": 21,
+								"end": 31,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 21
+									},
+									"end": {
+										"line": 1,
+										"column": 31
+									}
+								},
+								"expression": {
+									"type": "Identifier",
+									"start": 25,
+									"end": 30,
+									"loc": {
+										"start": {
+											"line": 1,
+											"column": 25
+										},
+										"end": {
+											"line": 1,
+											"column": 30
+										}
+									},
+									"name": "items"
+								}
+							}
+						]
+					}
+				}
+			],
+			"kind": "const"
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/jsx_spread_child/input.ts
+++ b/test/jsx_spread_child/input.ts
@@ -1,0 +1,1 @@
+const element = <div>{...items}</div>;


### PR DESCRIPTION
Recognize an ellipsis at the start of a JSX child expression container and emit a JSXSpreadChild node.

Add a minimal TSX regression fixture.

- Close: #78 