### PR TITLE
fix: register enum runtime bindings

### DIFF
--- a/.changeset/enum-local-export.md
+++ b/.changeset/enum-local-export.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Register enum declarations as local runtime bindings.

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,8 @@ const acornScope = {
 	BIND_FLAGS_TS_IMPORT: 0b01000000_0000_00,
 	BIND_FLAGS_TS_ENUM: 0b00000100_0000_00,
 	BIND_FLAGS_TS_CONST_ENUM: 0b00001000_0000_00,
+	BIND_TS_ENUM: 1 | 0b00000100_0000_00,
+	BIND_TS_CONST_ENUM: 1 | 0b00000100_0000_00 | 0b00001000_0000_00,
 	BIND_FLAGS_CLASS: 0b00000010_0000_00
 	// function
 };
@@ -979,7 +981,10 @@ export function tsPlugin(options?: {
 				if (properties.declare) node.declare = true;
 				this.expectContextual('enum');
 				node.id = this.parseIdent();
-				this.checkLValSimple(node.id);
+				const bindingType = properties.const
+					? acornScope.BIND_TS_CONST_ENUM
+					: acornScope.BIND_TS_ENUM;
+				this.checkLValSimple(node.id, bindingType);
 
 				this.expect(tt.braceL);
 				node.members = this.tsParseDelimitedList('EnumMembers', this.tsParseEnumMember.bind(this));

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,8 @@ const acornScope = {
 	BIND_FLAGS_TS_IMPORT: 0b01000000_0000_00,
 	BIND_FLAGS_TS_ENUM: 0b00000100_0000_00,
 	BIND_FLAGS_TS_CONST_ENUM: 0b00001000_0000_00,
-	BIND_TS_ENUM: 1 | 0b00000100_0000_00,
-	BIND_TS_CONST_ENUM: 1 | 0b00000100_0000_00 | 0b00001000_0000_00,
+	BIND_TS_ENUM: 2 | 0b00000100_0000_00,
+	BIND_TS_CONST_ENUM: 2 | 0b00000100_0000_00 | 0b00001000_0000_00,
 	BIND_FLAGS_CLASS: 0b00000010_0000_00
 	// function
 };
@@ -5311,6 +5311,9 @@ export function tsPlugin(options?: {
 						this.raise(pos, `type '${name}' has already been declared.`);
 					}
 					scope.types.push(name);
+				} else if (bindingType & acornScope.BIND_FLAGS_TS_ENUM) {
+					if (scope.enums.includes(name)) return;
+					super.declareName(name, acornScope.BIND_LEXICAL, pos);
 				} else {
 					super.declareName(name, bindingType, pos);
 				}

--- a/test/enum_local_export/expected.json
+++ b/test/enum_local_export/expected.json
@@ -1,0 +1,150 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 46,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 6,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "TSEnumDeclaration",
+			"start": 0,
+			"end": 22,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 5,
+				"end": 14,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 5
+					},
+					"end": {
+						"line": 1,
+						"column": 14
+					}
+				},
+				"name": "Direction"
+			},
+			"members": [
+				{
+					"type": "TSEnumMember",
+					"start": 18,
+					"end": 20,
+					"loc": {
+						"start": {
+							"line": 2,
+							"column": 1
+						},
+						"end": {
+							"line": 2,
+							"column": 3
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 18,
+						"end": 20,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 1
+							},
+							"end": {
+								"line": 2,
+								"column": 3
+							}
+						},
+						"name": "Up"
+					}
+				}
+			]
+		},
+		{
+			"type": "ExportNamedDeclaration",
+			"start": 24,
+			"end": 45,
+			"loc": {
+				"start": {
+					"line": 5,
+					"column": 0
+				},
+				"end": {
+					"line": 5,
+					"column": 21
+				}
+			},
+			"exportKind": "value",
+			"declaration": null,
+			"specifiers": [
+				{
+					"type": "ExportSpecifier",
+					"start": 33,
+					"end": 42,
+					"loc": {
+						"start": {
+							"line": 5,
+							"column": 9
+						},
+						"end": {
+							"line": 5,
+							"column": 18
+						}
+					},
+					"local": {
+						"type": "Identifier",
+						"start": 33,
+						"end": 42,
+						"loc": {
+							"start": {
+								"line": 5,
+								"column": 9
+							},
+							"end": {
+								"line": 5,
+								"column": 18
+							}
+						},
+						"name": "Direction"
+					},
+					"exported": {
+						"type": "Identifier",
+						"start": 33,
+						"end": 42,
+						"loc": {
+							"start": {
+								"line": 5,
+								"column": 9
+							},
+							"end": {
+								"line": 5,
+								"column": 18
+							}
+						},
+						"name": "Direction"
+					},
+					"exportKind": "value"
+				}
+			],
+			"source": null
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/enum_local_export/input.ts
+++ b/test/enum_local_export/input.ts
@@ -1,0 +1,5 @@
+enum Direction {
+	Up
+}
+
+export { Direction };

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import * as acorn from 'acorn';
 import { tsPlugin } from '../src';
 import type { AcornTypeScript } from '../src/types';
+import { parseSource } from './utils';
 
 function checkAcornTypeScriptUndefined(acornTypeScript?: AcornTypeScript): boolean {
 	if (!acornTypeScript) return false;
@@ -70,5 +71,10 @@ describe('static plugin', () => {
 		);
 
 		expect(checkAcornTypeScriptEqual(acornTypeScriptOne, acornTypeScriptTwo)).toBe(true);
+	});
+
+	it('keeps enums block-scoped while allowing same-scope merging', () => {
+		expect(() => parseSource('function f() { { enum A {} } let A; }')).not.toThrow();
+		expect(() => parseSource('enum A { X } enum A { Y }')).not.toThrow();
 	});
 });


### PR DESCRIPTION
Declare regular and const enums in the Acorn scope while retaining their TypeScript binding flags.

Add regression coverage for exporting a locally declared enum.

- Close: #85 