### PR TITLE
fix: allow static auto-accessors

### DIFF
--- a/.changeset/static-auto-accessor.md
+++ b/.changeset/static-auto-accessor.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Allow `static` auto-accessor class fields.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2169,7 +2169,6 @@ export function tsPlugin(options?: {
 							this.raise(this.start, TypeScriptError.DuplicateModifier({ modifier }));
 						} else {
 							incompatible(startLoc, modifier, 'accessor', 'readonly');
-							incompatible(startLoc, modifier, 'accessor', 'static');
 							incompatible(startLoc, modifier, 'accessor', 'override');
 
 							modifiedMap[modifier] = modifier;

--- a/test/class_static_accessor/expected.json
+++ b/test/class_static_accessor/expected.json
@@ -1,0 +1,118 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 46,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 4,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "ClassDeclaration",
+			"start": 0,
+			"end": 45,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 6,
+				"end": 13,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 6
+					},
+					"end": {
+						"line": 1,
+						"column": 13
+					}
+				},
+				"name": "Counter"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 14,
+				"end": 45,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 14
+					},
+					"end": {
+						"line": 3,
+						"column": 1
+					}
+				},
+				"body": [
+					{
+						"type": "PropertyDefinition",
+						"start": 17,
+						"end": 43,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 1
+							},
+							"end": {
+								"line": 2,
+								"column": 27
+							}
+						},
+						"static": true,
+						"accessor": true,
+						"computed": false,
+						"key": {
+							"type": "Identifier",
+							"start": 33,
+							"end": 38,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 17
+								},
+								"end": {
+									"line": 2,
+									"column": 22
+								}
+							},
+							"name": "value"
+						},
+						"value": {
+							"type": "Literal",
+							"start": 41,
+							"end": 42,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 25
+								},
+								"end": {
+									"line": 2,
+									"column": 26
+								}
+							},
+							"value": 0,
+							"raw": "0"
+						}
+					}
+				]
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/class_static_accessor/input.ts
+++ b/test/class_static_accessor/input.ts
@@ -1,0 +1,3 @@
+class Counter {
+	static accessor value = 0;
+}


### PR DESCRIPTION
Remove the obsolete incompatibility between the static and accessor modifiers.

Add a regression fixture for a static auto-accessor field.

- Close: #87 