### PR TITLE
fix: decode JSX entities correctly

### DIFF
--- a/.changeset/jsx-entity-decoding.md
+++ b/.changeset/jsx-entity-decoding.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Fix JSX entity decoding: decode numeric entities above the basic multilingual plane, and stop resolving named entities through the prototype chain.

--- a/src/extentions/jsx/index.ts
+++ b/src/extentions/jsx/index.ts
@@ -6,6 +6,19 @@ import type * as acornNamespace from 'acorn';
 const hexNumber = /^[\da-fA-F]+$/;
 const decimalNumber = /^\d+$/;
 
+/**
+ * Decode a numeric JSX entity.
+ *
+ * `String.fromCharCode` keeps only the low 16 bits, which silently mangles
+ * astral code points: `&#x1f600;` came back truncated to U+F600 rather than
+ * the intended emoji.
+ * Returns undefined for a value outside the Unicode range, so the caller
+ * leaves the text as written rather than throwing.
+ */
+function codePointToString(code: number): string | undefined {
+	return code <= 0x10ffff ? String.fromCodePoint(code) : undefined;
+}
+
 // Transforms JSX element name to string.
 
 function getQualifiedJSXName(object) {
@@ -157,12 +170,14 @@ export default function generateJsxParser(
 					if (str[0] === '#') {
 						if (str[1] === 'x') {
 							str = str.substr(2);
-							if (hexNumber.test(str)) entity = String.fromCharCode(parseInt(str, 16));
+							if (hexNumber.test(str)) entity = codePointToString(parseInt(str, 16));
 						} else {
 							str = str.substr(1);
-							if (decimalNumber.test(str)) entity = String.fromCharCode(parseInt(str, 10));
+							if (decimalNumber.test(str)) entity = codePointToString(parseInt(str, 10));
 						}
-					} else {
+					} else if (Object.prototype.hasOwnProperty.call(XHTMLEntities, str)) {
+						// Guarded, so an inherited name such as `&toString;` or `&constructor;`
+						// is not mistaken for an entity.
 						entity = XHTMLEntities[str];
 					}
 					break;

--- a/test/jsxEntities.test.ts
+++ b/test/jsxEntities.test.ts
@@ -1,0 +1,59 @@
+import * as acorn from 'acorn';
+import { describe, expect, it } from 'vitest';
+import { tsPlugin } from '../src';
+
+const Parser = acorn.Parser.extend(tsPlugin({ jsx: true }) as any);
+
+function parseJsxText(source: string): string {
+	const ast = Parser.parse(source, {
+		ecmaVersion: 'latest',
+		sourceType: 'module'
+	});
+
+	const values: string[] = [];
+	const visit = (node: any) => {
+		if (!node || typeof node !== 'object') return;
+		if (node.type === 'JSXText') values.push(node.value);
+		for (const key of Object.keys(node)) {
+			const value = node[key];
+			if (Array.isArray(value)) value.forEach(visit);
+			else if (value && typeof value === 'object') visit(value);
+		}
+	};
+	visit(ast);
+
+	return values.join('');
+}
+
+describe('jsx entities', () => {
+	it('decodes a numeric entity outside the basic plane', () => {
+		// `String.fromCharCode` kept only the low 16 bits, turning this into U+F600.
+		expect(parseJsxText('const a = <div>&#x1f600;</div>;')).toBe('\u{1f600}');
+		expect(parseJsxText('const a = <div>&#128512;</div>;')).toBe('\u{1f600}');
+	});
+
+	it('leaves an inherited property name untouched', () => {
+		// A bare lookup found these on Object.prototype, so they resolved to
+		// functions instead of staying literal text.
+		expect(parseJsxText('const a = <div>&toString;</div>;')).toBe('&toString;');
+		expect(parseJsxText('const a = <div>&constructor;</div>;')).toBe('&constructor;');
+		expect(parseJsxText('const a = <div>&__proto__;</div>;')).toBe('&__proto__;');
+	});
+
+	it('still decodes named and basic-plane entities', () => {
+		expect(parseJsxText('const a = <div>&amp;</div>;')).toBe('&');
+		expect(parseJsxText('const a = <div>&nbsp;</div>;')).toBe(' ');
+		expect(parseJsxText('const a = <div>&#x41;</div>;')).toBe('A');
+		expect(parseJsxText('const a = <div>&#65;</div>;')).toBe('A');
+	});
+
+	it('leaves an out-of-range code point as written', () => {
+		expect(parseJsxText('const a = <div>&#x110000;</div>;')).toBe('&#x110000;');
+	});
+
+	it('reproduces the reported example', () => {
+		expect(parseJsxText('const element = <div>&#x1f600; &toString;</div>;')).toBe(
+			'\u{1f600} &toString;'
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #80. Two independent problems in `jsx_readEntity`, both reachable from ordinary JSX text.

### 1. Numeric entities above the basic plane were truncated

`String.fromCharCode` keeps only the low 16 bits, so `String.fromCharCode(0x1f600)` yields U+F600 rather than the emoji. `&#x1f600;` decoded to U+F600, and `&#x110000;` wrapped around to a NUL byte.

These are now decoded with `String.fromCodePoint`, and a value past the Unicode range is treated as *not* an entity, so the source is left as written. That matches the existing fallback for unrecognised entities instead of throwing a `RangeError`.

### 2. Named entity lookup read through the prototype chain

`XHTMLEntities[str]` reaches `Object.prototype` for inherited names, and the result is truthy, so it was accepted as a decoded entity. `&toString;` genuinely inserted the text `function toString() { [native code] }` into the JSX.

The lookup is now guarded with `hasOwnProperty`, so `&toString;`, `&constructor;` and `&__proto__;` stay literal.

## Verification

The reported input now parses exactly as expected:

- `JSXText` value: the emoji, a space, then the literal `&toString;`
- code points: `U+1f600 U+20 U+26 U+74 U+6f U+53 ...`

## Tests

`test/jsxEntities.test.ts` covers both bugs, the unaffected cases, and the reported example. Reverting only `src/` fails four of the five with precisely the reported symptoms:

- decodes a numeric entity outside the basic plane: got U+F600, expected the emoji
- leaves an inherited property name untouched: got `function toString() { [native code] }`, expected `&toString;`
- leaves an out-of-range code point as written: got a NUL character, expected `&#x110000;`
- reproduces the reported example: got the function source spliced into the text

The fifth (`still decodes named and basic-plane entities` covering `&amp;`, `&nbsp;`, `&#x41;`, `&#65;`) passes either way by design: it is the no-regression guard.

## Note on the existing suite

`vitest run` reports **131 failures on this branch and 135 on a clean checkout**. The delta is exactly the four tests above flipping to pass, and no new failure appears.

All remaining failures are pre-existing fixture mismatches in `test/run.test.ts` (`arrow-function_type_*`, `class_*`, and four `jsx_*` fixtures). I confirmed the same four `jsx_*` fixtures fail identically before and after this change:

- with fix: `jsx_issue_29_jsx`, `jsx_issue_46`, `jsx_issue_48`, `jsx_tsx`
- clean: `jsx_issue_29_jsx`, `jsx_issue_46`, `jsx_issue_48`, `jsx_tsx`

`prettier --check` also flags `src/extentions/jsx/index.ts` on a clean checkout, so I left the formatting alone rather than mixing an unrelated reformat into this diff.
