### PR TITLE
fix: isolate namespace variable scopes

### DIFF
--- a/.changeset/calm-scopes-parse.md
+++ b/.changeset/calm-scopes-parse.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+fix: isolate namespace variable scopes

--- a/src/index.ts
+++ b/src/index.ts
@@ -5235,11 +5235,13 @@ export function tsPlugin(options?: {
 			}
 
 			enterScope(flags: any) {
-				if (flags === TS_SCOPE_TS_MODULE) {
+				const isTypeScriptModule = flags === TS_SCOPE_TS_MODULE;
+				if (isTypeScriptModule) {
 					this.importsStack.push([]);
 				}
 
-				super.enterScope(flags);
+				const acornFlags = isTypeScriptModule ? flags | acornScope.SCOPE_CLASS_STATIC_BLOCK : flags;
+				super.enterScope(acornFlags);
 				const scope = super.currentScope();
 
 				scope.types = [];
@@ -5256,7 +5258,7 @@ export function tsPlugin(options?: {
 			exitScope() {
 				const scope = super.currentScope();
 
-				if (scope.flags === TS_SCOPE_TS_MODULE) {
+				if (scope.flags & TS_SCOPE_TS_MODULE) {
 					this.importsStack.pop();
 				}
 

--- a/src/scopeflags.ts
+++ b/src/scopeflags.ts
@@ -1,9 +1,9 @@
 // Each scope gets a bitset that may contain these flags
 // prettier-ignore
 export const
-  // Up to 0b00100000000 is reserved in acorn.
-  TS_SCOPE_OTHER        = 0b01000000000,
-  TS_SCOPE_TS_MODULE    = 0b10000000000;
+  // Keep TypeScript scope flags outside Acorn's internal scope flag range.
+  TS_SCOPE_OTHER        = 1 << 20,
+  TS_SCOPE_TS_MODULE    = 1 << 21;
 
 // These flags are meant to be _only_ used inside the Scope class (or subclasses).
 // prettier-ignore

--- a/test/namespace_var_scope/expected.json
+++ b/test/namespace_var_scope/expected.json
@@ -1,0 +1,226 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 51,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 6,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "VariableDeclaration",
+			"start": 0,
+			"end": 14,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 14
+				}
+			},
+			"declarations": [
+				{
+					"type": "VariableDeclarator",
+					"start": 4,
+					"end": 13,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 4
+						},
+						"end": {
+							"line": 1,
+							"column": 13
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 4,
+						"end": 13,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 4
+							},
+							"end": {
+								"line": 1,
+								"column": 13
+							}
+						},
+						"name": "x",
+						"typeAnnotation": {
+							"type": "TSTypeAnnotation",
+							"start": 5,
+							"end": 13,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 5
+								},
+								"end": {
+									"line": 1,
+									"column": 13
+								}
+							},
+							"typeAnnotation": {
+								"type": "TSNumberKeyword",
+								"start": 7,
+								"end": 13,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 7
+									},
+									"end": {
+										"line": 1,
+										"column": 13
+									}
+								}
+							}
+						}
+					},
+					"init": null
+				}
+			],
+			"kind": "let"
+		},
+		{
+			"type": "TSModuleDeclaration",
+			"start": 16,
+			"end": 50,
+			"loc": {
+				"start": {
+					"line": 3,
+					"column": 0
+				},
+				"end": {
+					"line": 5,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 26,
+				"end": 27,
+				"loc": {
+					"start": {
+						"line": 3,
+						"column": 10
+					},
+					"end": {
+						"line": 3,
+						"column": 11
+					}
+				},
+				"name": "N"
+			},
+			"body": {
+				"type": "TSModuleBlock",
+				"start": 28,
+				"end": 50,
+				"loc": {
+					"start": {
+						"line": 3,
+						"column": 12
+					},
+					"end": {
+						"line": 5,
+						"column": 1
+					}
+				},
+				"body": [
+					{
+						"type": "VariableDeclaration",
+						"start": 34,
+						"end": 48,
+						"loc": {
+							"start": {
+								"line": 4,
+								"column": 4
+							},
+							"end": {
+								"line": 4,
+								"column": 18
+							}
+						},
+						"declarations": [
+							{
+								"type": "VariableDeclarator",
+								"start": 38,
+								"end": 47,
+								"loc": {
+									"start": {
+										"line": 4,
+										"column": 8
+									},
+									"end": {
+										"line": 4,
+										"column": 17
+									}
+								},
+								"id": {
+									"type": "Identifier",
+									"start": 38,
+									"end": 47,
+									"loc": {
+										"start": {
+											"line": 4,
+											"column": 8
+										},
+										"end": {
+											"line": 4,
+											"column": 17
+										}
+									},
+									"name": "x",
+									"typeAnnotation": {
+										"type": "TSTypeAnnotation",
+										"start": 39,
+										"end": 47,
+										"loc": {
+											"start": {
+												"line": 4,
+												"column": 9
+											},
+											"end": {
+												"line": 4,
+												"column": 17
+											}
+										},
+										"typeAnnotation": {
+											"type": "TSNumberKeyword",
+											"start": 41,
+											"end": 47,
+											"loc": {
+												"start": {
+													"line": 4,
+													"column": 11
+												},
+												"end": {
+													"line": 4,
+													"column": 17
+												}
+											}
+										}
+									}
+								},
+								"init": null
+							}
+						],
+						"kind": "var"
+					}
+				]
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/namespace_var_scope/input.ts
+++ b/test/namespace_var_scope/input.ts
@@ -1,0 +1,5 @@
+let x: number;
+
+namespace N {
+    var x: number;
+}


### PR DESCRIPTION
Move TypeScript-only scope bits beyond Acorn's current internal range and treat module blocks as non-function var-scope boundaries.

Add a minimal parser fixture for an outer lexical binding and an inner namespace var.

- Close: #91 