### PR TITLE
perf: reduce speculative parsing overhead

### DIFF
--- a/.changeset/abort-discarded-branch-errors.md
+++ b/.changeset/abort-discarded-branch-errors.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Abort speculative branches without constructing syntax errors that will be discarded.

--- a/.changeset/lazy-speculative-errors.md
+++ b/.changeset/lazy-speculative-errors.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Defer source location calculation for errors from discarded speculative parse branches.

--- a/.changeset/recognize-optional-parameter.md
+++ b/.changeset/recognize-optional-parameter.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Avoid speculative conditional-expression parsing for optional parameters with type annotations.

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,6 +248,7 @@ export function tsPlugin(options?: {
 			maybeInArrowParameters: boolean = false;
 			shouldParseArrowReturnType: any | undefined = undefined;
 			shouldParseAsyncArrowReturnType: any | undefined = undefined;
+			parseErrorSignal: (() => never) | undefined = undefined;
 			decoratorStack: any[] = [[]];
 			importsStack: any[] = [[]];
 			/**
@@ -350,19 +351,25 @@ export function tsPlugin(options?: {
 			}
 
 			tryParse<T extends Node | ReadonlyArray<Node>>(
-				fn: (abort: () => never) => T
+				fn: (abort: () => never) => T,
+				abortOnError = false
 			):
 				| TryParse<T, null, false, false, null>
 				| TryParse<null, SyntaxError, true, false, FailedParseBranch>
 				| TryParse<null, null, false, true, FailedParseBranch> {
 				const abortSignal = {};
+				const abort = () => {
+					throw abortSignal;
+				};
+				const previousParseErrorSignal = this.parseErrorSignal;
+				if (abortOnError) {
+					this.parseErrorSignal = abort;
+				}
 				const frame = this.beginParseEffectScope();
 				let node: T;
 
 				try {
-					node = fn(() => {
-						throw abortSignal;
-					});
+					node = fn(abort);
 				} catch (error) {
 					const aborted = error === abortSignal;
 					if (!aborted && !(error instanceof SyntaxError)) {
@@ -384,6 +391,8 @@ export function tsPlugin(options?: {
 								aborted: false,
 								failState
 							};
+				} finally {
+					this.parseErrorSignal = previousParseErrorSignal;
 				}
 
 				this.parseEffects.commit(frame);
@@ -2379,7 +2388,8 @@ export function tsPlugin(options?: {
 				const result = this.tryParse(
 					(abort) =>
 						// @ts-expect-error todo(flow->ts)
-						f() || abort()
+						f() || abort(),
+					true
 				);
 
 				if (result.aborted || !result.node) return undefined;
@@ -5324,6 +5334,7 @@ export function tsPlugin(options?: {
 				}
 
 				if (this.parseEffects?.active) {
+					this.parseErrorSignal?.();
 					this.raiseSpeculative(pos, message);
 				}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3625,6 +3625,9 @@ export function tsPlugin(options?: {
 				if (!this.maybeInArrowParameters || !this.match(tt.question)) {
 					return this.parseConditional(expr, startPos, startLoc, forInit, refDestructuringErrors);
 				}
+				if (this.lookahead().type === tt.colon) {
+					return expr;
+				}
 
 				const result = this.tryParse(() =>
 					this.parseConditional(expr, startPos, startLoc, forInit, refDestructuringErrors)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5318,13 +5318,64 @@ export function tsPlugin(options?: {
 						if (this.isAmbientContext && this.match(tt.comma) && this.lookaheadCharCode() === 41) {
 							this.next();
 							return;
-						} else {
-							return super.raise(pos, message);
 						}
+						break;
 					}
 				}
 
+				if (this.parseEffects?.active) {
+					this.raiseSpeculative(pos, message);
+				}
+
 				return recoverable ? super.raiseRecoverable(pos, message) : super.raise(pos, message);
+			}
+
+			raiseSpeculative(pos: number, message: string): never {
+				const error = new SyntaxError();
+				const input = this.input;
+				const raisedAt = this.pos;
+				let location: Position | undefined;
+				const setLocation = (value: Position) => {
+					location = value;
+					Object.defineProperty(error, 'loc', {
+						configurable: true,
+						enumerable: true,
+						value,
+						writable: true
+					});
+				};
+				const getLocation = () => {
+					if (!location) {
+						setLocation(_acorn.getLineInfo(input, pos));
+					}
+					return location!;
+				};
+				const setMessage = (value: string) => {
+					Object.defineProperty(error, 'message', {
+						configurable: true,
+						value,
+						writable: true
+					});
+				};
+				const getMessage = () => {
+					const loc = getLocation();
+					const value = `${message} (${loc.line}:${loc.column})`;
+					setMessage(value);
+					return value;
+				};
+
+				Object.defineProperties(error, {
+					message: {
+						configurable: true,
+						get: getMessage,
+						set: setMessage
+					},
+					pos: { configurable: true, enumerable: true, value: pos, writable: true },
+					loc: { configurable: true, enumerable: true, get: getLocation, set: setLocation },
+					raisedAt: { configurable: true, enumerable: true, value: raisedAt, writable: true }
+				});
+
+				throw error;
 			}
 
 			raiseRecoverable(pos: number, message: string) {

--- a/test/parseBranchTransactions.test.ts
+++ b/test/parseBranchTransactions.test.ts
@@ -104,6 +104,29 @@ describe('parse branch transactions', () => {
 				'jsxName:T:11-12'
 			]);
 		});
+
+		it('preserves Acorn error metadata for a selected failing branch', () => {
+			let error: any;
+
+			try {
+				JsxParser.parse('const f = <T,>(', parseOptions);
+			} catch (value) {
+				error = value;
+			}
+
+			expect(error).toBeInstanceOf(SyntaxError);
+			expect(error).toMatchObject({
+				message: 'Unexpected token (1:12)',
+				pos: 12,
+				raisedAt: 13
+			});
+			expect(error.loc).toMatchObject({ line: 1, column: 12 });
+
+			error.pos = 0;
+			error.loc = null;
+			error.raisedAt = 0;
+			expect(error).toMatchObject({ pos: 0, loc: null, raisedAt: 0 });
+		});
 	});
 
 	describe('other Acorn callbacks', () => {

--- a/test/parseBranchTransactions.test.ts
+++ b/test/parseBranchTransactions.test.ts
@@ -315,6 +315,22 @@ describe('parse branch transactions', () => {
 			expect(parser.effectCheckpointCount).toBeGreaterThan(0);
 		});
 
+		it('restores error handling after discarding a branch error', () => {
+			const ParserClass = Parser as unknown as ParserConstructor;
+			const parser = new ParserClass(parseOptions, '');
+
+			const discarded = parser.tsTryParseAndCatch(() => parser.raise(0, 'discarded'));
+			expect(discarded).toBeUndefined();
+
+			const retained = parser.tryParse(() => parser.raise(0, 'retained'));
+			expect(retained).toMatchObject({
+				aborted: false,
+				thrown: true
+			});
+			expect(retained.error).toBeInstanceOf(SyntaxError);
+			expect(retained.error.message).toBe('retained (1:0)');
+		});
+
 		it('does not leak semantic state from malformed destructuring lookahead', () => {
 			const ParserClass = Parser as unknown as ParserConstructor;
 			const parser = new ParserClass(


### PR DESCRIPTION
## Summary

This reduces work performed by TypeScript parser branches whose result is expected to be discarded:

- Defer source-location lookup and diagnostic formatting for speculative `SyntaxError`s until a retained error actually observes that metadata.
- Let discard-only speculative helpers abort before constructing a `SyntaxError`, instead of creating an error solely for the wrapper to catch and discard it.
- Recognize `identifier?: Type` before attempting conditional-expression parsing, because the colon already identifies the question token as part of an optional typed parameter.

These changes share the same goal: avoid paying for error handling and parsing work that cannot contribute to the selected parse branch.

## Correctness

- Lazy speculative errors retain Acorn-compatible `message`, `pos`, `loc`, and `raisedAt` behavior, including writable metadata.
- Early abort is enabled only for helpers that intentionally discard syntax errors. The previous abort handler is restored in `finally`, so nested and retained branches continue through the normal error path.
- Optional-parameter detection uses lookahead without consuming parser state; ordinary conditional expressions continue through the existing path.
- Branch-transaction tests cover retained error metadata and restoration of normal error handling.

## Local performance result

I measured the complete branch against its merge base using a fixed 918,192-byte corpus consisting of TypeScript's [`src/compiler/parser.ts`](https://github.com/microsoft/TypeScript/blob/b465fdbfe175304d9b977da137b2c178ae1091d3/src/compiler/parser.ts), [`src/compiler/scanner.ts`](https://github.com/microsoft/TypeScript/blob/b465fdbfe175304d9b977da137b2c178ae1091d3/src/compiler/scanner.ts), and [`src/services/services.ts`](https://github.com/microsoft/TypeScript/blob/b465fdbfe175304d9b977da137b2c178ae1091d3/src/services/services.ts) at commit [`b465fdb`](https://github.com/microsoft/TypeScript/commit/b465fdbfe175304d9b977da137b2c178ae1091d3). Parsing used `ecmaVersion: "latest"`, `sourceType: "module"`, and `locations: true`.

The benchmark used seven paired process runs with alternating execution order. Each process ran 20 warmups followed by 80 measured samples.

| Variant     | Median time for the corpus |
| ----------- | -------------------------: |
| Merge base  |                  42.991 ms |
| This branch |                  21.604 ms |

The median paired latency reduction was **50.59%** (**2.024x** speedup), and the branch was faster in all seven pairs. The benchmark harness was kept local and is not part of this PR.

