### PR TITLE
perf: reuse the TypeScript keyword matcher

### DIFF
--- a/.changeset/reuse-keyword-regexp.md
+++ b/.changeset/reuse-keyword-regexp.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/acorn-typescript': patch
+---
+
+Reuse the TypeScript keyword matcher while scanning identifiers.

--- a/src/index.ts
+++ b/src/index.ts
@@ -677,7 +677,7 @@ export function tsPlugin(options?: {
 
 				if (this.keywords.test(word)) {
 					type = keywordTypes[word];
-				} else if (new RegExp(keywordsRegExp).test(word)) {
+				} else if (keywordsRegExp.test(word)) {
 					type = tokTypes[word];
 				}
 


### PR DESCRIPTION
## Summary

Identifier scanning currently passes the existing TypeScript keyword matcher to `new RegExp` before testing every non-JavaScript keyword candidate. That creates an equivalent `RegExp` instance on each visit even though the matcher is unchanged.

This PR tests the generated matcher directly, removing the repeated allocation and compilation work from identifier scanning.

## Correctness

The generated matcher has neither global nor sticky state, so repeated calls to `.test()` are equivalent to testing a newly constructed clone. Existing keyword parser tests and the full conformance suite verify that token classification remains unchanged.

## Local performance result

I measured the complete branch against its merge base using a fixed 918,192-byte corpus consisting of TypeScript's [`src/compiler/parser.ts`](https://github.com/microsoft/TypeScript/blob/b465fdbfe175304d9b977da137b2c178ae1091d3/src/compiler/parser.ts), [`src/compiler/scanner.ts`](https://github.com/microsoft/TypeScript/blob/b465fdbfe175304d9b977da137b2c178ae1091d3/src/compiler/scanner.ts), and [`src/services/services.ts`](https://github.com/microsoft/TypeScript/blob/b465fdbfe175304d9b977da137b2c178ae1091d3/src/services/services.ts) at commit [`b465fdb`](https://github.com/microsoft/TypeScript/commit/b465fdbfe175304d9b977da137b2c178ae1091d3). Parsing used `ecmaVersion: "latest"`, `sourceType: "module"`, and `locations: true`.

The benchmark used seven paired process runs with alternating execution order. Each process ran 20 warmups followed by 80 measured samples.

| Variant     | Median time for the corpus |
| ----------- | -------------------------: |
| Merge base  |                  41.800 ms |
| This branch |                  37.487 ms |

The median paired latency reduction was **10.60%** (**1.119x** speedup), and the branch was faster in all seven pairs. The benchmark harness was kept local and is not part of this PR.

