### PR TITLE
fix: allow JSX element after enum, interface, and namespace bodies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1005,6 +1005,7 @@ export function tsPlugin(options?: {
 
 				this.expect(tt.braceL);
 				node.members = this.tsParseDelimitedList('EnumMembers', this.tsParseEnumMember.bind(this));
+				this.exprAllowedAfterDeclarationBody();
 				this.expect(tt.braceR);
 				return this.finishNode(node, 'TSEnumDeclaration');
 			}
@@ -1019,6 +1020,7 @@ export function tsPlugin(options?: {
 					let stmt = this.parseStatement(null, true);
 					node.body.push(stmt);
 				}
+				this.exprAllowedAfterDeclarationBody();
 				this.next();
 				super.exitScope();
 				return this.finishNode(node, 'TSModuleBlock');
@@ -2558,8 +2560,13 @@ export function tsPlugin(options?: {
 				this.inType = true;
 				let members = this.tsParseList('TypeMembers', this.tsParseTypeMember.bind(this));
 				this.inType = oldInType;
+				this.exprAllowedAfterDeclarationBody();
 				this.expect(tt.braceR);
 				return members;
+			}
+
+			exprAllowedAfterDeclarationBody(): void {
+				this.exprAllowed = true;
 			}
 
 			tsParseAbstractDeclaration(node: any): any | undefined | null {

--- a/test/jsx_element_after_enum/expected.json
+++ b/test/jsx_element_after_enum/expected.json
@@ -1,0 +1,178 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 43,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 7,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "TSEnumDeclaration",
+			"start": 0,
+			"end": 31,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 4,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 5,
+				"end": 14,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 5
+					},
+					"end": {
+						"line": 1,
+						"column": 14
+					}
+				},
+				"name": "Direction"
+			},
+			"members": [
+				{
+					"type": "TSEnumMember",
+					"start": 19,
+					"end": 21,
+					"loc": {
+						"start": {
+							"line": 2,
+							"column": 2
+						},
+						"end": {
+							"line": 2,
+							"column": 4
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 19,
+						"end": 21,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 2
+							},
+							"end": {
+								"line": 2,
+								"column": 4
+							}
+						},
+						"name": "Up"
+					}
+				},
+				{
+					"type": "TSEnumMember",
+					"start": 25,
+					"end": 29,
+					"loc": {
+						"start": {
+							"line": 3,
+							"column": 2
+						},
+						"end": {
+							"line": 3,
+							"column": 6
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 25,
+						"end": 29,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 2
+							},
+							"end": {
+								"line": 3,
+								"column": 6
+							}
+						},
+						"name": "Down"
+					}
+				}
+			]
+		},
+		{
+			"type": "ExpressionStatement",
+			"start": 33,
+			"end": 42,
+			"loc": {
+				"start": {
+					"line": 6,
+					"column": 0
+				},
+				"end": {
+					"line": 6,
+					"column": 9
+				}
+			},
+			"expression": {
+				"type": "JSXElement",
+				"start": 33,
+				"end": 41,
+				"loc": {
+					"start": {
+						"line": 6,
+						"column": 0
+					},
+					"end": {
+						"line": 6,
+						"column": 8
+					}
+				},
+				"openingElement": {
+					"type": "JSXOpeningElement",
+					"start": 33,
+					"end": 41,
+					"loc": {
+						"start": {
+							"line": 6,
+							"column": 0
+						},
+						"end": {
+							"line": 6,
+							"column": 8
+						}
+					},
+					"name": {
+						"type": "JSXIdentifier",
+						"start": 34,
+						"end": 38,
+						"loc": {
+							"start": {
+								"line": 6,
+								"column": 1
+							},
+							"end": {
+								"line": 6,
+								"column": 5
+							}
+						},
+						"name": "span"
+					},
+					"attributes": [],
+					"selfClosing": true
+				},
+				"closingElement": null,
+				"children": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/jsx_element_after_enum/input.ts
+++ b/test/jsx_element_after_enum/input.ts
@@ -1,0 +1,6 @@
+enum Direction {
+  Up,
+  Down
+}
+
+<span />;

--- a/test/jsx_element_after_interface/expected.json
+++ b/test/jsx_element_after_interface/expected.json
@@ -1,0 +1,430 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 152,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 13,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "TSModuleDeclaration",
+			"start": 0,
+			"end": 106,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 6,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 18,
+				"end": 21,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 18
+					},
+					"end": {
+						"line": 1,
+						"column": 21
+					}
+				},
+				"name": "JSX"
+			},
+			"body": {
+				"type": "TSModuleBlock",
+				"start": 22,
+				"end": 106,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 22
+					},
+					"end": {
+						"line": 6,
+						"column": 1
+					}
+				},
+				"body": [
+					{
+						"type": "TSInterfaceDeclaration",
+						"start": 26,
+						"end": 46,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 2
+							},
+							"end": {
+								"line": 2,
+								"column": 22
+							}
+						},
+						"id": {
+							"type": "Identifier",
+							"start": 36,
+							"end": 43,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 12
+								},
+								"end": {
+									"line": 2,
+									"column": 19
+								}
+							},
+							"name": "Element"
+						},
+						"body": {
+							"type": "TSInterfaceBody",
+							"start": 44,
+							"end": 46,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 20
+								},
+								"end": {
+									"line": 2,
+									"column": 22
+								}
+							},
+							"body": []
+						}
+					},
+					{
+						"type": "TSInterfaceDeclaration",
+						"start": 49,
+						"end": 104,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 2
+							},
+							"end": {
+								"line": 5,
+								"column": 3
+							}
+						},
+						"id": {
+							"type": "Identifier",
+							"start": 59,
+							"end": 76,
+							"loc": {
+								"start": {
+									"line": 3,
+									"column": 12
+								},
+								"end": {
+									"line": 3,
+									"column": 29
+								}
+							},
+							"name": "IntrinsicElements"
+						},
+						"body": {
+							"type": "TSInterfaceBody",
+							"start": 77,
+							"end": 104,
+							"loc": {
+								"start": {
+									"line": 3,
+									"column": 30
+								},
+								"end": {
+									"line": 5,
+									"column": 3
+								}
+							},
+							"body": [
+								{
+									"type": "TSIndexSignature",
+									"start": 83,
+									"end": 100,
+									"loc": {
+										"start": {
+											"line": 4,
+											"column": 4
+										},
+										"end": {
+											"line": 4,
+											"column": 21
+										}
+									},
+									"parameters": [
+										{
+											"type": "Identifier",
+											"start": 84,
+											"end": 93,
+											"loc": {
+												"start": {
+													"line": 4,
+													"column": 5
+												},
+												"end": {
+													"line": 4,
+													"column": 14
+												}
+											},
+											"name": "x",
+											"typeAnnotation": {
+												"type": "TSTypeAnnotation",
+												"start": 85,
+												"end": 93,
+												"loc": {
+													"start": {
+														"line": 4,
+														"column": 6
+													},
+													"end": {
+														"line": 4,
+														"column": 14
+													}
+												},
+												"typeAnnotation": {
+													"type": "TSStringKeyword",
+													"start": 87,
+													"end": 93,
+													"loc": {
+														"start": {
+															"line": 4,
+															"column": 8
+														},
+														"end": {
+															"line": 4,
+															"column": 14
+														}
+													}
+												}
+											}
+										}
+									],
+									"typeAnnotation": {
+										"type": "TSTypeAnnotation",
+										"start": 94,
+										"end": 99,
+										"loc": {
+											"start": {
+												"line": 4,
+												"column": 15
+											},
+											"end": {
+												"line": 4,
+												"column": 20
+											}
+										},
+										"typeAnnotation": {
+											"type": "TSAnyKeyword",
+											"start": 96,
+											"end": 99,
+											"loc": {
+												"start": {
+													"line": 4,
+													"column": 17
+												},
+												"end": {
+													"line": 4,
+													"column": 20
+												}
+											}
+										}
+									}
+								}
+							]
+						}
+					}
+				]
+			},
+			"declare": true
+		},
+		{
+			"type": "TSInterfaceDeclaration",
+			"start": 108,
+			"end": 141,
+			"loc": {
+				"start": {
+					"line": 8,
+					"column": 0
+				},
+				"end": {
+					"line": 10,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 118,
+				"end": 123,
+				"loc": {
+					"start": {
+						"line": 8,
+						"column": 10
+					},
+					"end": {
+						"line": 8,
+						"column": 15
+					}
+				},
+				"name": "Props"
+			},
+			"body": {
+				"type": "TSInterfaceBody",
+				"start": 124,
+				"end": 141,
+				"loc": {
+					"start": {
+						"line": 8,
+						"column": 16
+					},
+					"end": {
+						"line": 10,
+						"column": 1
+					}
+				},
+				"body": [
+					{
+						"type": "TSPropertySignature",
+						"start": 128,
+						"end": 139,
+						"loc": {
+							"start": {
+								"line": 9,
+								"column": 2
+							},
+							"end": {
+								"line": 9,
+								"column": 13
+							}
+						},
+						"computed": false,
+						"key": {
+							"type": "Identifier",
+							"start": 128,
+							"end": 130,
+							"loc": {
+								"start": {
+									"line": 9,
+									"column": 2
+								},
+								"end": {
+									"line": 9,
+									"column": 4
+								}
+							},
+							"name": "id"
+						},
+						"typeAnnotation": {
+							"type": "TSTypeAnnotation",
+							"start": 130,
+							"end": 138,
+							"loc": {
+								"start": {
+									"line": 9,
+									"column": 4
+								},
+								"end": {
+									"line": 9,
+									"column": 12
+								}
+							},
+							"typeAnnotation": {
+								"type": "TSNumberKeyword",
+								"start": 132,
+								"end": 138,
+								"loc": {
+									"start": {
+										"line": 9,
+										"column": 6
+									},
+									"end": {
+										"line": 9,
+										"column": 12
+									}
+								}
+							}
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "ExpressionStatement",
+			"start": 143,
+			"end": 151,
+			"loc": {
+				"start": {
+					"line": 12,
+					"column": 0
+				},
+				"end": {
+					"line": 12,
+					"column": 8
+				}
+			},
+			"expression": {
+				"type": "JSXElement",
+				"start": 143,
+				"end": 150,
+				"loc": {
+					"start": {
+						"line": 12,
+						"column": 0
+					},
+					"end": {
+						"line": 12,
+						"column": 7
+					}
+				},
+				"openingElement": {
+					"type": "JSXOpeningElement",
+					"start": 143,
+					"end": 150,
+					"loc": {
+						"start": {
+							"line": 12,
+							"column": 0
+						},
+						"end": {
+							"line": 12,
+							"column": 7
+						}
+					},
+					"name": {
+						"type": "JSXIdentifier",
+						"start": 144,
+						"end": 147,
+						"loc": {
+							"start": {
+								"line": 12,
+								"column": 1
+							},
+							"end": {
+								"line": 12,
+								"column": 4
+							}
+						},
+						"name": "div"
+					},
+					"attributes": [],
+					"selfClosing": true
+				},
+				"closingElement": null,
+				"children": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/jsx_element_after_interface/input.ts
+++ b/test/jsx_element_after_interface/input.ts
@@ -1,0 +1,12 @@
+declare namespace JSX {
+  interface Element {}
+  interface IntrinsicElements {
+    [x: string]: any;
+  }
+}
+
+interface Props {
+  id: number;
+}
+
+<div />;

--- a/test/jsx_element_after_namespace/expected.json
+++ b/test/jsx_element_after_namespace/expected.json
@@ -1,0 +1,264 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 71,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 6,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "TSModuleDeclaration",
+			"start": 0,
+			"end": 52,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 1
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 10,
+				"end": 16,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 10
+					},
+					"end": {
+						"line": 1,
+						"column": 16
+					}
+				},
+				"name": "Shapes"
+			},
+			"body": {
+				"type": "TSModuleBlock",
+				"start": 17,
+				"end": 52,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 17
+					},
+					"end": {
+						"line": 3,
+						"column": 1
+					}
+				},
+				"body": [
+					{
+						"type": "ExportNamedDeclaration",
+						"start": 21,
+						"end": 50,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 2
+							},
+							"end": {
+								"line": 2,
+								"column": 31
+							}
+						},
+						"exportKind": "value",
+						"declaration": {
+							"type": "VariableDeclaration",
+							"start": 28,
+							"end": 50,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 9
+								},
+								"end": {
+									"line": 2,
+									"column": 31
+								}
+							},
+							"declarations": [
+								{
+									"type": "VariableDeclarator",
+									"start": 34,
+									"end": 49,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 15
+										},
+										"end": {
+											"line": 2,
+											"column": 30
+										}
+									},
+									"id": {
+										"type": "Identifier",
+										"start": 34,
+										"end": 38,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 15
+											},
+											"end": {
+												"line": 2,
+												"column": 19
+											}
+										},
+										"name": "name"
+									},
+									"init": {
+										"type": "Literal",
+										"start": 41,
+										"end": 49,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 22
+											},
+											"end": {
+												"line": 2,
+												"column": 30
+											}
+										},
+										"value": "shapes",
+										"raw": "'shapes'"
+									}
+								}
+							],
+							"kind": "const"
+						},
+						"specifiers": [],
+						"source": null
+					}
+				]
+			}
+		},
+		{
+			"type": "ExpressionStatement",
+			"start": 54,
+			"end": 70,
+			"loc": {
+				"start": {
+					"line": 5,
+					"column": 0
+				},
+				"end": {
+					"line": 5,
+					"column": 16
+				}
+			},
+			"expression": {
+				"type": "JSXElement",
+				"start": 54,
+				"end": 69,
+				"loc": {
+					"start": {
+						"line": 5,
+						"column": 0
+					},
+					"end": {
+						"line": 5,
+						"column": 15
+					}
+				},
+				"openingElement": {
+					"type": "JSXOpeningElement",
+					"start": 54,
+					"end": 69,
+					"loc": {
+						"start": {
+							"line": 5,
+							"column": 0
+						},
+						"end": {
+							"line": 5,
+							"column": 15
+						}
+					},
+					"name": {
+						"type": "JSXIdentifier",
+						"start": 55,
+						"end": 56,
+						"loc": {
+							"start": {
+								"line": 5,
+								"column": 1
+							},
+							"end": {
+								"line": 5,
+								"column": 2
+							}
+						},
+						"name": "a"
+					},
+					"attributes": [
+						{
+							"type": "JSXAttribute",
+							"start": 57,
+							"end": 66,
+							"loc": {
+								"start": {
+									"line": 5,
+									"column": 3
+								},
+								"end": {
+									"line": 5,
+									"column": 12
+								}
+							},
+							"name": {
+								"type": "JSXIdentifier",
+								"start": 57,
+								"end": 61,
+								"loc": {
+									"start": {
+										"line": 5,
+										"column": 3
+									},
+									"end": {
+										"line": 5,
+										"column": 7
+									}
+								},
+								"name": "href"
+							},
+							"value": {
+								"type": "Literal",
+								"start": 62,
+								"end": 66,
+								"loc": {
+									"start": {
+										"line": 5,
+										"column": 8
+									},
+									"end": {
+										"line": 5,
+										"column": 12
+									}
+								},
+								"value": "/x",
+								"raw": "\"/x\""
+							}
+						}
+					],
+					"selfClosing": true
+				},
+				"closingElement": null,
+				"children": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/jsx_element_after_namespace/input.ts
+++ b/test/jsx_element_after_namespace/input.ts
@@ -1,0 +1,5 @@
+namespace Shapes {
+  export const name = 'shapes';
+}
+
+<a href="/x" />;


### PR DESCRIPTION
Set exprAllowed before consuming the closing brace so the following `<` tokenizes as JSX rather than a relational operator.