### PR TITLE
fix: tokenize `@` after a type annotation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -281,6 +281,11 @@ export function tsPlugin(options?: {
 					return this.finishOp(tt.relational, 1);
 				}
 
+				if (code === 64) {
+					++this.pos;
+					return this.finishToken(tokTypes.at);
+				}
+
 				return super.getTokenFromCode(code);
 			}
 

--- a/test/decorator_after_type_annotation/expected.json
+++ b/test/decorator_after_type_annotation/expected.json
@@ -1,0 +1,616 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 130,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 15,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "VariableDeclaration",
+			"start": 0,
+			"end": 20,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 20
+				}
+			},
+			"declare": true,
+			"declarations": [
+				{
+					"type": "VariableDeclarator",
+					"start": 12,
+					"end": 20,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 12
+						},
+						"end": {
+							"line": 1,
+							"column": 20
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 12,
+						"end": 20,
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 12
+							},
+							"end": {
+								"line": 1,
+								"column": 20
+							}
+						},
+						"name": "dec",
+						"typeAnnotation": {
+							"type": "TSTypeAnnotation",
+							"start": 15,
+							"end": 20,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 15
+								},
+								"end": {
+									"line": 1,
+									"column": 20
+								}
+							},
+							"typeAnnotation": {
+								"type": "TSAnyKeyword",
+								"start": 17,
+								"end": 20,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 17
+									},
+									"end": {
+										"line": 1,
+										"column": 20
+									}
+								}
+							}
+						}
+					},
+					"init": null
+				}
+			],
+			"kind": "var"
+		},
+		{
+			"type": "ExportNamedDeclaration",
+			"start": 29,
+			"end": 46,
+			"loc": {
+				"start": {
+					"line": 4,
+					"column": 0
+				},
+				"end": {
+					"line": 4,
+					"column": 17
+				}
+			},
+			"exportKind": "value",
+			"declaration": {
+				"type": "ClassDeclaration",
+				"start": 22,
+				"end": 46,
+				"loc": {
+					"start": {
+						"line": 3,
+						"column": 0
+					},
+					"end": {
+						"line": 4,
+						"column": 17
+					}
+				},
+				"decorators": [
+					{
+						"type": "Decorator",
+						"start": 22,
+						"end": 28,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 0
+							},
+							"end": {
+								"line": 3,
+								"column": 6
+							}
+						},
+						"expression": {
+							"type": "CallExpression",
+							"start": 23,
+							"end": 28,
+							"loc": {
+								"start": {
+									"line": 3,
+									"column": 1
+								},
+								"end": {
+									"line": 3,
+									"column": 6
+								}
+							},
+							"callee": {
+								"type": "Identifier",
+								"start": 23,
+								"end": 26,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 1
+									},
+									"end": {
+										"line": 3,
+										"column": 4
+									}
+								},
+								"name": "dec"
+							},
+							"arguments": []
+						}
+					}
+				],
+				"id": {
+					"type": "Identifier",
+					"start": 42,
+					"end": 43,
+					"loc": {
+						"start": {
+							"line": 4,
+							"column": 13
+						},
+						"end": {
+							"line": 4,
+							"column": 14
+						}
+					},
+					"name": "A"
+				},
+				"superClass": null,
+				"body": {
+					"type": "ClassBody",
+					"start": 44,
+					"end": 46,
+					"loc": {
+						"start": {
+							"line": 4,
+							"column": 15
+						},
+						"end": {
+							"line": 4,
+							"column": 17
+						}
+					},
+					"body": []
+				}
+			},
+			"specifiers": [],
+			"source": null
+		},
+		{
+			"type": "VariableDeclaration",
+			"start": 48,
+			"end": 65,
+			"loc": {
+				"start": {
+					"line": 6,
+					"column": 0
+				},
+				"end": {
+					"line": 6,
+					"column": 17
+				}
+			},
+			"declarations": [
+				{
+					"type": "VariableDeclarator",
+					"start": 52,
+					"end": 65,
+					"loc": {
+						"start": {
+							"line": 6,
+							"column": 4
+						},
+						"end": {
+							"line": 6,
+							"column": 17
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 52,
+						"end": 65,
+						"loc": {
+							"start": {
+								"line": 6,
+								"column": 4
+							},
+							"end": {
+								"line": 6,
+								"column": 17
+							}
+						},
+						"name": "count",
+						"typeAnnotation": {
+							"type": "TSTypeAnnotation",
+							"start": 57,
+							"end": 65,
+							"loc": {
+								"start": {
+									"line": 6,
+									"column": 9
+								},
+								"end": {
+									"line": 6,
+									"column": 17
+								}
+							},
+							"typeAnnotation": {
+								"type": "TSNumberKeyword",
+								"start": 59,
+								"end": 65,
+								"loc": {
+									"start": {
+										"line": 6,
+										"column": 11
+									},
+									"end": {
+										"line": 6,
+										"column": 17
+									}
+								}
+							}
+						}
+					},
+					"init": null
+				}
+			],
+			"kind": "let"
+		},
+		{
+			"type": "ClassDeclaration",
+			"start": 67,
+			"end": 84,
+			"loc": {
+				"start": {
+					"line": 8,
+					"column": 0
+				},
+				"end": {
+					"line": 9,
+					"column": 10
+				}
+			},
+			"decorators": [
+				{
+					"type": "Decorator",
+					"start": 67,
+					"end": 73,
+					"loc": {
+						"start": {
+							"line": 8,
+							"column": 0
+						},
+						"end": {
+							"line": 8,
+							"column": 6
+						}
+					},
+					"expression": {
+						"type": "CallExpression",
+						"start": 68,
+						"end": 73,
+						"loc": {
+							"start": {
+								"line": 8,
+								"column": 1
+							},
+							"end": {
+								"line": 8,
+								"column": 6
+							}
+						},
+						"callee": {
+							"type": "Identifier",
+							"start": 68,
+							"end": 71,
+							"loc": {
+								"start": {
+									"line": 8,
+									"column": 1
+								},
+								"end": {
+									"line": 8,
+									"column": 4
+								}
+							},
+							"name": "dec"
+						},
+						"arguments": []
+					}
+				}
+			],
+			"id": {
+				"type": "Identifier",
+				"start": 80,
+				"end": 81,
+				"loc": {
+					"start": {
+						"line": 9,
+						"column": 6
+					},
+					"end": {
+						"line": 9,
+						"column": 7
+					}
+				},
+				"name": "B"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 82,
+				"end": 84,
+				"loc": {
+					"start": {
+						"line": 9,
+						"column": 8
+					},
+					"end": {
+						"line": 9,
+						"column": 10
+					}
+				},
+				"body": []
+			}
+		},
+		{
+			"type": "VariableDeclaration",
+			"start": 86,
+			"end": 110,
+			"loc": {
+				"start": {
+					"line": 11,
+					"column": 0
+				},
+				"end": {
+					"line": 11,
+					"column": 24
+				}
+			},
+			"declarations": [
+				{
+					"type": "VariableDeclarator",
+					"start": 90,
+					"end": 110,
+					"loc": {
+						"start": {
+							"line": 11,
+							"column": 4
+						},
+						"end": {
+							"line": 11,
+							"column": 24
+						}
+					},
+					"id": {
+						"type": "Identifier",
+						"start": 90,
+						"end": 110,
+						"loc": {
+							"start": {
+								"line": 11,
+								"column": 4
+							},
+							"end": {
+								"line": 11,
+								"column": 24
+							}
+						},
+						"name": "items",
+						"typeAnnotation": {
+							"type": "TSTypeAnnotation",
+							"start": 95,
+							"end": 110,
+							"loc": {
+								"start": {
+									"line": 11,
+									"column": 9
+								},
+								"end": {
+									"line": 11,
+									"column": 24
+								}
+							},
+							"typeAnnotation": {
+								"type": "TSTypeReference",
+								"start": 97,
+								"end": 110,
+								"loc": {
+									"start": {
+										"line": 11,
+										"column": 11
+									},
+									"end": {
+										"line": 11,
+										"column": 24
+									}
+								},
+								"typeName": {
+									"type": "Identifier",
+									"start": 97,
+									"end": 102,
+									"loc": {
+										"start": {
+											"line": 11,
+											"column": 11
+										},
+										"end": {
+											"line": 11,
+											"column": 16
+										}
+									},
+									"name": "Array"
+								},
+								"typeArguments": {
+									"type": "TSTypeParameterInstantiation",
+									"start": 102,
+									"end": 110,
+									"loc": {
+										"start": {
+											"line": 11,
+											"column": 16
+										},
+										"end": {
+											"line": 11,
+											"column": 24
+										}
+									},
+									"params": [
+										{
+											"type": "TSStringKeyword",
+											"start": 103,
+											"end": 109,
+											"loc": {
+												"start": {
+													"line": 11,
+													"column": 17
+												},
+												"end": {
+													"line": 11,
+													"column": 23
+												}
+											}
+										}
+									]
+								}
+							}
+						}
+					},
+					"init": null
+				}
+			],
+			"kind": "let"
+		},
+		{
+			"type": "ClassDeclaration",
+			"start": 112,
+			"end": 129,
+			"loc": {
+				"start": {
+					"line": 13,
+					"column": 0
+				},
+				"end": {
+					"line": 14,
+					"column": 10
+				}
+			},
+			"decorators": [
+				{
+					"type": "Decorator",
+					"start": 112,
+					"end": 118,
+					"loc": {
+						"start": {
+							"line": 13,
+							"column": 0
+						},
+						"end": {
+							"line": 13,
+							"column": 6
+						}
+					},
+					"expression": {
+						"type": "CallExpression",
+						"start": 113,
+						"end": 118,
+						"loc": {
+							"start": {
+								"line": 13,
+								"column": 1
+							},
+							"end": {
+								"line": 13,
+								"column": 6
+							}
+						},
+						"callee": {
+							"type": "Identifier",
+							"start": 113,
+							"end": 116,
+							"loc": {
+								"start": {
+									"line": 13,
+									"column": 1
+								},
+								"end": {
+									"line": 13,
+									"column": 4
+								}
+							},
+							"name": "dec"
+						},
+						"arguments": []
+					}
+				}
+			],
+			"id": {
+				"type": "Identifier",
+				"start": 125,
+				"end": 126,
+				"loc": {
+					"start": {
+						"line": 14,
+						"column": 6
+					},
+					"end": {
+						"line": 14,
+						"column": 7
+					}
+				},
+				"name": "C"
+			},
+			"superClass": null,
+			"body": {
+				"type": "ClassBody",
+				"start": 127,
+				"end": 129,
+				"loc": {
+					"start": {
+						"line": 14,
+						"column": 8
+					},
+					"end": {
+						"line": 14,
+						"column": 10
+					}
+				},
+				"body": []
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/decorator_after_type_annotation/input.ts
+++ b/test/decorator_after_type_annotation/input.ts
@@ -1,0 +1,14 @@
+declare var dec: any
+
+@dec()
+export class A {}
+
+let count: number
+
+@dec()
+class B {}
+
+let items: Array<string>
+
+@dec()
+class C {}


### PR DESCRIPTION
Decorators following a variable type annotation (e.g. `let x: number` then `@dec() class C {}`) threw "Unexpected character" because the tokenizer was still in type context and core acorn has no `@` token.