### PR TITLE
fix: support import attributes in import types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1614,6 +1614,7 @@ export function tsPlugin(options?: {
 
 				// For compatibility to estree we cannot call parseLiteral directly here
 				node.argument = this.parseExprAtom();
+				node.options = this.eat(tt.comma) && !this.match(tt.parenR) ? this.parseExprAtom() : null;
 				this.expect(tt.parenR);
 				if (this.eat(tt.dot)) {
 					// In this instance, the entity name will actually itself be a

--- a/test/import_type_with_attributes/expected.json
+++ b/test/import_type_with_attributes/expected.json
@@ -1,0 +1,747 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 288,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 8,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "TSTypeAliasDeclaration",
+			"start": 0,
+			"end": 99,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 99
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 5,
+				"end": 21,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 5
+					},
+					"end": {
+						"line": 1,
+						"column": 21
+					}
+				},
+				"name": "RequireInterface"
+			},
+			"typeAnnotation": {
+				"type": "TSImportType",
+				"start": 24,
+				"end": 98,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 24
+					},
+					"end": {
+						"line": 1,
+						"column": 98
+					}
+				},
+				"argument": {
+					"type": "Literal",
+					"start": 31,
+					"end": 36,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 31
+						},
+						"end": {
+							"line": 1,
+							"column": 36
+						}
+					},
+					"value": "pkg",
+					"raw": "'pkg'"
+				},
+				"options": {
+					"type": "ObjectExpression",
+					"start": 38,
+					"end": 80,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 38
+						},
+						"end": {
+							"line": 1,
+							"column": 80
+						}
+					},
+					"properties": [
+						{
+							"type": "Property",
+							"start": 40,
+							"end": 78,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 40
+								},
+								"end": {
+									"line": 1,
+									"column": 78
+								}
+							},
+							"method": false,
+							"shorthand": false,
+							"computed": false,
+							"key": {
+								"type": "Identifier",
+								"start": 40,
+								"end": 44,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 40
+									},
+									"end": {
+										"line": 1,
+										"column": 44
+									}
+								},
+								"name": "with"
+							},
+							"value": {
+								"type": "ObjectExpression",
+								"start": 46,
+								"end": 78,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 46
+									},
+									"end": {
+										"line": 1,
+										"column": 78
+									}
+								},
+								"properties": [
+									{
+										"type": "Property",
+										"start": 48,
+										"end": 76,
+										"loc": {
+											"start": {
+												"line": 1,
+												"column": 48
+											},
+											"end": {
+												"line": 1,
+												"column": 76
+											}
+										},
+										"method": false,
+										"shorthand": false,
+										"computed": false,
+										"key": {
+											"type": "Literal",
+											"start": 48,
+											"end": 65,
+											"loc": {
+												"start": {
+													"line": 1,
+													"column": 48
+												},
+												"end": {
+													"line": 1,
+													"column": 65
+												}
+											},
+											"value": "resolution-mode",
+											"raw": "'resolution-mode'"
+										},
+										"value": {
+											"type": "Literal",
+											"start": 67,
+											"end": 76,
+											"loc": {
+												"start": {
+													"line": 1,
+													"column": 67
+												},
+												"end": {
+													"line": 1,
+													"column": 76
+												}
+											},
+											"value": "require",
+											"raw": "'require'"
+										},
+										"kind": "init"
+									}
+								]
+							},
+							"kind": "init"
+						}
+					]
+				},
+				"qualifier": {
+					"type": "Identifier",
+					"start": 82,
+					"end": 98,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 82
+						},
+						"end": {
+							"line": 1,
+							"column": 98
+						}
+					},
+					"name": "RequireInterface"
+				}
+			}
+		},
+		{
+			"type": "TSTypeAliasDeclaration",
+			"start": 101,
+			"end": 184,
+			"loc": {
+				"start": {
+					"line": 3,
+					"column": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 83
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 106,
+				"end": 115,
+				"loc": {
+					"start": {
+						"line": 3,
+						"column": 5
+					},
+					"end": {
+						"line": 3,
+						"column": 14
+					}
+				},
+				"name": "ImportedX"
+			},
+			"typeAnnotation": {
+				"type": "TSTypeQuery",
+				"start": 118,
+				"end": 183,
+				"loc": {
+					"start": {
+						"line": 3,
+						"column": 17
+					},
+					"end": {
+						"line": 3,
+						"column": 82
+					}
+				},
+				"exprName": {
+					"type": "TSImportType",
+					"start": 125,
+					"end": 183,
+					"loc": {
+						"start": {
+							"line": 3,
+							"column": 24
+						},
+						"end": {
+							"line": 3,
+							"column": 82
+						}
+					},
+					"argument": {
+						"type": "Literal",
+						"start": 132,
+						"end": 137,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 31
+							},
+							"end": {
+								"line": 3,
+								"column": 36
+							}
+						},
+						"value": "foo",
+						"raw": "'foo'"
+					},
+					"options": {
+						"type": "ObjectExpression",
+						"start": 139,
+						"end": 180,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 38
+							},
+							"end": {
+								"line": 3,
+								"column": 79
+							}
+						},
+						"properties": [
+							{
+								"type": "Property",
+								"start": 141,
+								"end": 178,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 40
+									},
+									"end": {
+										"line": 3,
+										"column": 77
+									}
+								},
+								"method": false,
+								"shorthand": false,
+								"computed": false,
+								"key": {
+									"type": "Identifier",
+									"start": 141,
+									"end": 145,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 40
+										},
+										"end": {
+											"line": 3,
+											"column": 44
+										}
+									},
+									"name": "with"
+								},
+								"value": {
+									"type": "ObjectExpression",
+									"start": 147,
+									"end": 178,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 46
+										},
+										"end": {
+											"line": 3,
+											"column": 77
+										}
+									},
+									"properties": [
+										{
+											"type": "Property",
+											"start": 149,
+											"end": 176,
+											"loc": {
+												"start": {
+													"line": 3,
+													"column": 48
+												},
+												"end": {
+													"line": 3,
+													"column": 75
+												}
+											},
+											"method": false,
+											"shorthand": false,
+											"computed": false,
+											"key": {
+												"type": "Literal",
+												"start": 149,
+												"end": 166,
+												"loc": {
+													"start": {
+														"line": 3,
+														"column": 48
+													},
+													"end": {
+														"line": 3,
+														"column": 65
+													}
+												},
+												"value": "resolution-mode",
+												"raw": "'resolution-mode'"
+											},
+											"value": {
+												"type": "Literal",
+												"start": 168,
+												"end": 176,
+												"loc": {
+													"start": {
+														"line": 3,
+														"column": 67
+													},
+													"end": {
+														"line": 3,
+														"column": 75
+													}
+												},
+												"value": "import",
+												"raw": "'import'"
+											},
+											"kind": "init"
+										}
+									]
+								},
+								"kind": "init"
+							}
+						]
+					},
+					"qualifier": {
+						"type": "Identifier",
+						"start": 182,
+						"end": 183,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 81
+							},
+							"end": {
+								"line": 3,
+								"column": 82
+							}
+						},
+						"name": "x"
+					}
+				}
+			}
+		},
+		{
+			"type": "TSTypeAliasDeclaration",
+			"start": 186,
+			"end": 246,
+			"loc": {
+				"start": {
+					"line": 5,
+					"column": 0
+				},
+				"end": {
+					"line": 5,
+					"column": 60
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 191,
+				"end": 197,
+				"loc": {
+					"start": {
+						"line": 5,
+						"column": 5
+					},
+					"end": {
+						"line": 5,
+						"column": 11
+					}
+				},
+				"name": "Legacy"
+			},
+			"typeAnnotation": {
+				"type": "TSImportType",
+				"start": 200,
+				"end": 245,
+				"loc": {
+					"start": {
+						"line": 5,
+						"column": 14
+					},
+					"end": {
+						"line": 5,
+						"column": 59
+					}
+				},
+				"argument": {
+					"type": "Literal",
+					"start": 207,
+					"end": 212,
+					"loc": {
+						"start": {
+							"line": 5,
+							"column": 21
+						},
+						"end": {
+							"line": 5,
+							"column": 26
+						}
+					},
+					"value": "foo",
+					"raw": "'foo'"
+				},
+				"options": {
+					"type": "ObjectExpression",
+					"start": 214,
+					"end": 242,
+					"loc": {
+						"start": {
+							"line": 5,
+							"column": 28
+						},
+						"end": {
+							"line": 5,
+							"column": 56
+						}
+					},
+					"properties": [
+						{
+							"type": "Property",
+							"start": 216,
+							"end": 240,
+							"loc": {
+								"start": {
+									"line": 5,
+									"column": 30
+								},
+								"end": {
+									"line": 5,
+									"column": 54
+								}
+							},
+							"method": false,
+							"shorthand": false,
+							"computed": false,
+							"key": {
+								"type": "Identifier",
+								"start": 216,
+								"end": 222,
+								"loc": {
+									"start": {
+										"line": 5,
+										"column": 30
+									},
+									"end": {
+										"line": 5,
+										"column": 36
+									}
+								},
+								"name": "assert"
+							},
+							"value": {
+								"type": "ObjectExpression",
+								"start": 224,
+								"end": 240,
+								"loc": {
+									"start": {
+										"line": 5,
+										"column": 38
+									},
+									"end": {
+										"line": 5,
+										"column": 54
+									}
+								},
+								"properties": [
+									{
+										"type": "Property",
+										"start": 226,
+										"end": 238,
+										"loc": {
+											"start": {
+												"line": 5,
+												"column": 40
+											},
+											"end": {
+												"line": 5,
+												"column": 52
+											}
+										},
+										"method": false,
+										"shorthand": false,
+										"computed": false,
+										"key": {
+											"type": "Identifier",
+											"start": 226,
+											"end": 230,
+											"loc": {
+												"start": {
+													"line": 5,
+													"column": 40
+												},
+												"end": {
+													"line": 5,
+													"column": 44
+												}
+											},
+											"name": "type"
+										},
+										"value": {
+											"type": "Literal",
+											"start": 232,
+											"end": 238,
+											"loc": {
+												"start": {
+													"line": 5,
+													"column": 46
+												},
+												"end": {
+													"line": 5,
+													"column": 52
+												}
+											},
+											"value": "json",
+											"raw": "'json'"
+										},
+										"kind": "init"
+									}
+								]
+							},
+							"kind": "init"
+						}
+					]
+				},
+				"qualifier": {
+					"type": "Identifier",
+					"start": 244,
+					"end": 245,
+					"loc": {
+						"start": {
+							"line": 5,
+							"column": 58
+						},
+						"end": {
+							"line": 5,
+							"column": 59
+						}
+					},
+					"name": "X"
+				}
+			}
+		},
+		{
+			"type": "TSTypeAliasDeclaration",
+			"start": 248,
+			"end": 287,
+			"loc": {
+				"start": {
+					"line": 7,
+					"column": 0
+				},
+				"end": {
+					"line": 7,
+					"column": 39
+				}
+			},
+			"id": {
+				"type": "Identifier",
+				"start": 253,
+				"end": 258,
+				"loc": {
+					"start": {
+						"line": 7,
+						"column": 5
+					},
+					"end": {
+						"line": 7,
+						"column": 10
+					}
+				},
+				"name": "Plain"
+			},
+			"typeAnnotation": {
+				"type": "TSImportType",
+				"start": 261,
+				"end": 286,
+				"loc": {
+					"start": {
+						"line": 7,
+						"column": 13
+					},
+					"end": {
+						"line": 7,
+						"column": 38
+					}
+				},
+				"argument": {
+					"type": "Literal",
+					"start": 268,
+					"end": 273,
+					"loc": {
+						"start": {
+							"line": 7,
+							"column": 20
+						},
+						"end": {
+							"line": 7,
+							"column": 25
+						}
+					},
+					"value": "foo",
+					"raw": "'foo'"
+				},
+				"options": null,
+				"qualifier": {
+					"type": "Identifier",
+					"start": 275,
+					"end": 278,
+					"loc": {
+						"start": {
+							"line": 7,
+							"column": 27
+						},
+						"end": {
+							"line": 7,
+							"column": 30
+						}
+					},
+					"name": "Bar"
+				},
+				"typeArguments": {
+					"type": "TSTypeParameterInstantiation",
+					"start": 278,
+					"end": 286,
+					"loc": {
+						"start": {
+							"line": 7,
+							"column": 30
+						},
+						"end": {
+							"line": 7,
+							"column": 38
+						}
+					},
+					"params": [
+						{
+							"type": "TSStringKeyword",
+							"start": 279,
+							"end": 285,
+							"loc": {
+								"start": {
+									"line": 7,
+									"column": 31
+								},
+								"end": {
+									"line": 7,
+									"column": 37
+								}
+							}
+						}
+					]
+				}
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/import_type_with_attributes/input.ts
+++ b/test/import_type_with_attributes/input.ts
@@ -1,0 +1,7 @@
+type RequireInterface = import('pkg', { with: { 'resolution-mode': 'require' } }).RequireInterface;
+
+type ImportedX = typeof import('foo', { with: { 'resolution-mode': 'import' } }).x;
+
+type Legacy = import('foo', { assert: { type: 'json' } }).X;
+
+type Plain = import('foo').Bar<string>;


### PR DESCRIPTION
Parse the optional second argument of `import('x', { with: ... })` in type positions and expose it as `options` on TSImportType