### PR TITLE
fix: delegate dynamic import parsing to acorn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,10 @@ declare module 'acorn' {
 	export const lineBreakG: any;
 	export const nonASCIIwhitespace: any;
 	export const tokContexts: any;
+
+	interface Parser {
+		parseDynamicImport(node: any): any;
+	}
 }
 
 const skipWhiteSpace = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
@@ -3177,28 +3181,14 @@ export function tsPlugin(options?: {
 				return this.finishNode(node, 'ExportAllDeclaration');
 			}
 
-			parseDynamicImport(node) {
-				this.next(); // skip `(`
+			parseDynamicImport(node: any): any {
+				const result = super.parseDynamicImport(node);
 
-				// Parse node.source.
-				node.source = this.parseMaybeAssign();
-
-				if (this.eat(tt.comma)) {
-					const expr = this.parseExpression();
-					node.arguments = [expr];
+				if (result.options != null) {
+					result.arguments = [result.options];
 				}
 
-				// Verify ending.
-				if (!this.eat(tt.parenR)) {
-					const errorPos = this.start;
-					if (this.eat(tt.comma) && this.eat(tt.parenR)) {
-						this.raiseRecoverable(errorPos, 'Trailing comma is not allowed in import()');
-					} else {
-						this.unexpected(errorPos);
-					}
-				}
-
-				return this.finishNode(node, 'ImportExpression');
+				return result;
 			}
 
 			parseExport(node: any, exports: any): any {

--- a/test/assert_dynamic_import_assert/expected.json
+++ b/test/assert_dynamic_import_assert/expected.json
@@ -58,6 +58,127 @@
 					"value": "./foo.json",
 					"raw": "\"./foo.json\""
 				},
+				"options": {
+					"type": "ObjectExpression",
+					"start": 21,
+					"end": 47,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 21
+						},
+						"end": {
+							"line": 1,
+							"column": 47
+						}
+					},
+					"properties": [
+						{
+							"type": "Property",
+							"start": 23,
+							"end": 45,
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 23
+								},
+								"end": {
+									"line": 1,
+									"column": 45
+								}
+							},
+							"method": false,
+							"shorthand": false,
+							"computed": false,
+							"key": {
+								"type": "Identifier",
+								"start": 23,
+								"end": 27,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 23
+									},
+									"end": {
+										"line": 1,
+										"column": 27
+									}
+								},
+								"name": "with"
+							},
+							"value": {
+								"type": "ObjectExpression",
+								"start": 29,
+								"end": 45,
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 29
+									},
+									"end": {
+										"line": 1,
+										"column": 45
+									}
+								},
+								"properties": [
+									{
+										"type": "Property",
+										"start": 31,
+										"end": 43,
+										"loc": {
+											"start": {
+												"line": 1,
+												"column": 31
+											},
+											"end": {
+												"line": 1,
+												"column": 43
+											}
+										},
+										"method": false,
+										"shorthand": false,
+										"computed": false,
+										"key": {
+											"type": "Identifier",
+											"start": 31,
+											"end": 35,
+											"loc": {
+												"start": {
+													"line": 1,
+													"column": 31
+												},
+												"end": {
+													"line": 1,
+													"column": 35
+												}
+											},
+											"name": "type"
+										},
+										"value": {
+											"type": "Literal",
+											"start": 37,
+											"end": 43,
+											"loc": {
+												"start": {
+													"line": 1,
+													"column": 37
+												},
+												"end": {
+													"line": 1,
+													"column": 43
+												}
+											},
+											"value": "json",
+											"raw": "\"json\""
+										},
+										"kind": "init"
+									}
+								]
+							},
+							"kind": "init"
+						}
+					]
+				},
 				"arguments": [
 					{
 						"type": "ObjectExpression",

--- a/test/dynamic_import_trailing_comma/expected.json
+++ b/test/dynamic_import_trailing_comma/expected.json
@@ -1,0 +1,648 @@
+{
+	"type": "Program",
+	"start": 0,
+	"end": 116,
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 4,
+			"column": 0
+		}
+	},
+	"body": [
+		{
+			"type": "ExpressionStatement",
+			"start": 0,
+			"end": 18,
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 18
+				}
+			},
+			"expression": {
+				"type": "ImportExpression",
+				"start": 0,
+				"end": 17,
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 0
+					},
+					"end": {
+						"line": 1,
+						"column": 17
+					}
+				},
+				"source": {
+					"type": "Literal",
+					"start": 7,
+					"end": 15,
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 7
+						},
+						"end": {
+							"line": 1,
+							"column": 15
+						}
+					},
+					"value": "./a.js",
+					"raw": "'./a.js'"
+				},
+				"options": null
+			}
+		},
+		{
+			"type": "ExpressionStatement",
+			"start": 19,
+			"end": 67,
+			"loc": {
+				"start": {
+					"line": 2,
+					"column": 0
+				},
+				"end": {
+					"line": 2,
+					"column": 48
+				}
+			},
+			"expression": {
+				"type": "ImportExpression",
+				"start": 19,
+				"end": 66,
+				"loc": {
+					"start": {
+						"line": 2,
+						"column": 0
+					},
+					"end": {
+						"line": 2,
+						"column": 47
+					}
+				},
+				"source": {
+					"type": "Literal",
+					"start": 26,
+					"end": 36,
+					"loc": {
+						"start": {
+							"line": 2,
+							"column": 7
+						},
+						"end": {
+							"line": 2,
+							"column": 17
+						}
+					},
+					"value": "./b.json",
+					"raw": "'./b.json'"
+				},
+				"options": {
+					"type": "ObjectExpression",
+					"start": 38,
+					"end": 64,
+					"loc": {
+						"start": {
+							"line": 2,
+							"column": 19
+						},
+						"end": {
+							"line": 2,
+							"column": 45
+						}
+					},
+					"properties": [
+						{
+							"type": "Property",
+							"start": 40,
+							"end": 62,
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 21
+								},
+								"end": {
+									"line": 2,
+									"column": 43
+								}
+							},
+							"method": false,
+							"shorthand": false,
+							"computed": false,
+							"key": {
+								"type": "Identifier",
+								"start": 40,
+								"end": 44,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 21
+									},
+									"end": {
+										"line": 2,
+										"column": 25
+									}
+								},
+								"name": "with"
+							},
+							"value": {
+								"type": "ObjectExpression",
+								"start": 46,
+								"end": 62,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 27
+									},
+									"end": {
+										"line": 2,
+										"column": 43
+									}
+								},
+								"properties": [
+									{
+										"type": "Property",
+										"start": 48,
+										"end": 60,
+										"loc": {
+											"start": {
+												"line": 2,
+												"column": 29
+											},
+											"end": {
+												"line": 2,
+												"column": 41
+											}
+										},
+										"method": false,
+										"shorthand": false,
+										"computed": false,
+										"key": {
+											"type": "Identifier",
+											"start": 48,
+											"end": 52,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 29
+												},
+												"end": {
+													"line": 2,
+													"column": 33
+												}
+											},
+											"name": "type"
+										},
+										"value": {
+											"type": "Literal",
+											"start": 54,
+											"end": 60,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 35
+												},
+												"end": {
+													"line": 2,
+													"column": 41
+												}
+											},
+											"value": "json",
+											"raw": "'json'"
+										},
+										"kind": "init"
+									}
+								]
+							},
+							"kind": "init"
+						}
+					]
+				},
+				"arguments": [
+					{
+						"type": "ObjectExpression",
+						"start": 38,
+						"end": 64,
+						"loc": {
+							"start": {
+								"line": 2,
+								"column": 19
+							},
+							"end": {
+								"line": 2,
+								"column": 45
+							}
+						},
+						"properties": [
+							{
+								"type": "Property",
+								"start": 40,
+								"end": 62,
+								"loc": {
+									"start": {
+										"line": 2,
+										"column": 21
+									},
+									"end": {
+										"line": 2,
+										"column": 43
+									}
+								},
+								"method": false,
+								"shorthand": false,
+								"computed": false,
+								"key": {
+									"type": "Identifier",
+									"start": 40,
+									"end": 44,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 21
+										},
+										"end": {
+											"line": 2,
+											"column": 25
+										}
+									},
+									"name": "with"
+								},
+								"value": {
+									"type": "ObjectExpression",
+									"start": 46,
+									"end": 62,
+									"loc": {
+										"start": {
+											"line": 2,
+											"column": 27
+										},
+										"end": {
+											"line": 2,
+											"column": 43
+										}
+									},
+									"properties": [
+										{
+											"type": "Property",
+											"start": 48,
+											"end": 60,
+											"loc": {
+												"start": {
+													"line": 2,
+													"column": 29
+												},
+												"end": {
+													"line": 2,
+													"column": 41
+												}
+											},
+											"method": false,
+											"shorthand": false,
+											"computed": false,
+											"key": {
+												"type": "Identifier",
+												"start": 48,
+												"end": 52,
+												"loc": {
+													"start": {
+														"line": 2,
+														"column": 29
+													},
+													"end": {
+														"line": 2,
+														"column": 33
+													}
+												},
+												"name": "type"
+											},
+											"value": {
+												"type": "Literal",
+												"start": 54,
+												"end": 60,
+												"loc": {
+													"start": {
+														"line": 2,
+														"column": 35
+													},
+													"end": {
+														"line": 2,
+														"column": 41
+													}
+												},
+												"value": "json",
+												"raw": "'json'"
+											},
+											"kind": "init"
+										}
+									]
+								},
+								"kind": "init"
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"type": "ExpressionStatement",
+			"start": 68,
+			"end": 115,
+			"loc": {
+				"start": {
+					"line": 3,
+					"column": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 47
+				}
+			},
+			"expression": {
+				"type": "ImportExpression",
+				"start": 68,
+				"end": 114,
+				"loc": {
+					"start": {
+						"line": 3,
+						"column": 0
+					},
+					"end": {
+						"line": 3,
+						"column": 46
+					}
+				},
+				"source": {
+					"type": "Literal",
+					"start": 75,
+					"end": 85,
+					"loc": {
+						"start": {
+							"line": 3,
+							"column": 7
+						},
+						"end": {
+							"line": 3,
+							"column": 17
+						}
+					},
+					"value": "./c.json",
+					"raw": "'./c.json'"
+				},
+				"options": {
+					"type": "ObjectExpression",
+					"start": 87,
+					"end": 113,
+					"loc": {
+						"start": {
+							"line": 3,
+							"column": 19
+						},
+						"end": {
+							"line": 3,
+							"column": 45
+						}
+					},
+					"properties": [
+						{
+							"type": "Property",
+							"start": 89,
+							"end": 111,
+							"loc": {
+								"start": {
+									"line": 3,
+									"column": 21
+								},
+								"end": {
+									"line": 3,
+									"column": 43
+								}
+							},
+							"method": false,
+							"shorthand": false,
+							"computed": false,
+							"key": {
+								"type": "Identifier",
+								"start": 89,
+								"end": 93,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 21
+									},
+									"end": {
+										"line": 3,
+										"column": 25
+									}
+								},
+								"name": "with"
+							},
+							"value": {
+								"type": "ObjectExpression",
+								"start": 95,
+								"end": 111,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 27
+									},
+									"end": {
+										"line": 3,
+										"column": 43
+									}
+								},
+								"properties": [
+									{
+										"type": "Property",
+										"start": 97,
+										"end": 109,
+										"loc": {
+											"start": {
+												"line": 3,
+												"column": 29
+											},
+											"end": {
+												"line": 3,
+												"column": 41
+											}
+										},
+										"method": false,
+										"shorthand": false,
+										"computed": false,
+										"key": {
+											"type": "Identifier",
+											"start": 97,
+											"end": 101,
+											"loc": {
+												"start": {
+													"line": 3,
+													"column": 29
+												},
+												"end": {
+													"line": 3,
+													"column": 33
+												}
+											},
+											"name": "type"
+										},
+										"value": {
+											"type": "Literal",
+											"start": 103,
+											"end": 109,
+											"loc": {
+												"start": {
+													"line": 3,
+													"column": 35
+												},
+												"end": {
+													"line": 3,
+													"column": 41
+												}
+											},
+											"value": "json",
+											"raw": "'json'"
+										},
+										"kind": "init"
+									}
+								]
+							},
+							"kind": "init"
+						}
+					]
+				},
+				"arguments": [
+					{
+						"type": "ObjectExpression",
+						"start": 87,
+						"end": 113,
+						"loc": {
+							"start": {
+								"line": 3,
+								"column": 19
+							},
+							"end": {
+								"line": 3,
+								"column": 45
+							}
+						},
+						"properties": [
+							{
+								"type": "Property",
+								"start": 89,
+								"end": 111,
+								"loc": {
+									"start": {
+										"line": 3,
+										"column": 21
+									},
+									"end": {
+										"line": 3,
+										"column": 43
+									}
+								},
+								"method": false,
+								"shorthand": false,
+								"computed": false,
+								"key": {
+									"type": "Identifier",
+									"start": 89,
+									"end": 93,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 21
+										},
+										"end": {
+											"line": 3,
+											"column": 25
+										}
+									},
+									"name": "with"
+								},
+								"value": {
+									"type": "ObjectExpression",
+									"start": 95,
+									"end": 111,
+									"loc": {
+										"start": {
+											"line": 3,
+											"column": 27
+										},
+										"end": {
+											"line": 3,
+											"column": 43
+										}
+									},
+									"properties": [
+										{
+											"type": "Property",
+											"start": 97,
+											"end": 109,
+											"loc": {
+												"start": {
+													"line": 3,
+													"column": 29
+												},
+												"end": {
+													"line": 3,
+													"column": 41
+												}
+											},
+											"method": false,
+											"shorthand": false,
+											"computed": false,
+											"key": {
+												"type": "Identifier",
+												"start": 97,
+												"end": 101,
+												"loc": {
+													"start": {
+														"line": 3,
+														"column": 29
+													},
+													"end": {
+														"line": 3,
+														"column": 33
+													}
+												},
+												"name": "type"
+											},
+											"value": {
+												"type": "Literal",
+												"start": 103,
+												"end": 109,
+												"loc": {
+													"start": {
+														"line": 3,
+														"column": 35
+													},
+													"end": {
+														"line": 3,
+														"column": 41
+													}
+												},
+												"value": "json",
+												"raw": "'json'"
+											},
+											"kind": "init"
+										}
+									]
+								},
+								"kind": "init"
+							}
+						]
+					}
+				]
+			}
+		}
+	],
+	"sourceType": "module"
+}

--- a/test/dynamic_import_trailing_comma/input.ts
+++ b/test/dynamic_import_trailing_comma/input.ts
@@ -1,0 +1,3 @@
+import('./a.js',);
+import('./b.json', { with: { type: 'json' } },);
+import('./c.json', { with: { type: 'json' } });

--- a/test/run_test262.js
+++ b/test/run_test262.js
@@ -40,26 +40,6 @@ const WHITELIST = [
 	'language/module-code/early-dup-export-id-as.js',
 	'language/module-code/early-dup-export-id.js',
 	'language/module-code/early-dup-export-star-as-dflt.js',
-	// import assert
-	'language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-arrow-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-async-function-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-block-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-do-while-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-else-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-function-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-function-return-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-if-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/nested-while-not-extensible-args.js',
-	'language/expressions/dynamic-import/syntax/invalid/top-level-not-extensible-args.js',
 	// various stuff
 	'staging/sm/fields/await-identifier-module-3.js',
 	'staging/sm/module/duplicate-exported-names-in-single-export-declaration.js',
@@ -67,13 +47,6 @@ const WHITELIST = [
 	'staging/sm/module/module-export-name-star.js',
 	'staging/sm/String/make-normalize-generateddata-input.py' // python??
 ].flatMap((s) => [s + ' (default)', s + ' (strict mode)']);
-
-WHITELIST.push(
-	'language/expressions/dynamic-import/syntax/invalid/nested-with-expression-not-extensible-args.js (default)'
-);
-WHITELIST.push(
-	'language/expressions/dynamic-import/syntax/invalid/nested-with-not-extensible-args.js (default)'
-);
 
 run(
 	(content, { sourceType }) => {


### PR DESCRIPTION
The custom parseDynamicImport rejected trailing commas and accepted `import(x, a, b)` as a sequence expression. acorn 8.14 handles both correctly and populates ESTree `options`, so call through to it and mirror `options` into `arguments` for backwards compatibility.